### PR TITLE
ui/ux: 홈 화면 꿀통(Honey Pot) 비주얼 컴포넌트 적용

### DIFF
--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -2,6 +2,8 @@
 import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
 import { toast } from 'vue3-toastify'
+import HoneyPot from '@/components/HoneyPot.vue'
+import { useHoneyPot } from '@/composables/useHoneyPot'
 
 const weekdays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 
@@ -196,6 +198,7 @@ const historyItems = [
 const calendarTitle = computed(
   () => `${currentMonth.value.year()}년 ${currentMonth.value.month() + 1}월`,
 )
+const { displayPercentage, fillPercentage, guidelinePercentage } = useHoneyPot(800000, 555000, 360000)
 const visibleHistoryCount = ref(3)
 const recentItems = computed(() => historyItems.slice(0, visibleHistoryCount.value))
 const canLoadMoreHistory = computed(() => visibleHistoryCount.value < historyItems.length)
@@ -270,7 +273,15 @@ function loadMoreHistory() {
         <section class="hero-section">
           <p class="page-title">내 주식 어디갔어?</p>
 
-          <div class="bee-slot" aria-hidden="true"></div>
+          <div class="bee-slot" aria-hidden="true">
+            <div class="honey-pot-stage">
+              <HoneyPot
+                :display-value="displayPercentage"
+                :fill-percentage="fillPercentage"
+                :guideline-percentage="guidelinePercentage"
+              />
+            </div>
+          </div>
 
           <div class="balance-copy">
             <p class="balance-label">이번 달 생활비 남음</p>
@@ -430,8 +441,21 @@ function loadMoreHistory() {
 }
 
 .bee-slot {
-  height: 18.75rem;
-  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 16.75rem;
+  margin-top: 0.5rem;
+  overflow: visible;
+}
+
+.honey-pot-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  transform: translateX(0.25rem) scale(0.88);
+  transform-origin: center top;
 }
 
 .balance-copy {
@@ -874,7 +898,12 @@ function loadMoreHistory() {
   }
 
   .bee-slot {
-    height: 14rem;
+    height: 13.5rem;
+    margin-top: 0.3rem;
+  }
+
+  .honey-pot-stage {
+    transform: translateX(0.1rem) scale(0.74);
   }
 
   .balance-label {


### PR DESCRIPTION
## 🚀 PR 개요
- 작업 내용 요약:
  홈 화면 상단에 미리 비워두었던 비주얼 영역에 `HoneyPot` 컴포넌트를 적용했습니다.
  기존 빈 슬롯을 실제 꿀통 비주얼로 교체하고, 홈 히어로 영역 안에서 자연스럽게 보이도록 크기와 위치를 함께 조정했습니다.
- 관련 이슈: #24

---

## ✨ 변경 사항
- `home` 상단 hero 영역의 빈 슬롯에 `HoneyPot` 비주얼 컴포넌트 연결
- 꿀통 표시값, 채움 비율, 가이드라인 비율을 홈 화면에서 주입하도록 설정
- iPhone Pro Max 기준으로 꿀통 크기와 상단 여백을 조정하고, 모바일 구간 스케일도 함께 보정

---

## 🧩 작업 유형
- [ ] 🐛 Bug Fix
- [x] ✨ Feature
- [ ] 🔧 Refactor
- [x] 🎨 UI/UX
- [ ] 🔌 API
- [ ] ⚡ Performance
- [ ] ⚙️ Config / Build

---

## 📍 주요 변경 파일
- `src/pages/homePage/HomePage.vue`
- `src/components/HoneyPot.vue`

---

## 🖼️ 스크린샷 (선택)
> UI 변경 시 필수

정상실행 확인

<img width="918" height="1231" alt="image" src="https://github.com/user-attachments/assets/3b521ac9-e8fa-46c6-865c-4284eeb7de71" />

- 홈 화면 상단 hero 영역에 꿀통 비주얼이 적용된 화면 첨부
- iPhone Pro Max 기준에서 상단 비주얼과 하단 카드 간 간격이 자연스럽게 보이는지 함께 확인

---

## 🧪 테스트 방법
1. `npm run dev` 실행
2. `/home` 진입 후 상단 꿀통 비주얼이 정상 렌더되는지 확인
3. `npm run build` 실행 후 빌드가 정상 통과하는지 확인

---

## ⚠️ 체크리스트
- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 기존 기능 영향 없음
- [x] 반응형/UI 확인 (필요 시)

---

## 💬 기타 사항
- 이번 PR은 `home` 화면 상단 꿀통 비주얼 적용에만 범위를 한정했습니다.
- 기존 `HoneyPot` 컴포넌트와 composable을 재사용해 다른 팀원 작업 범위와의 충돌을 최소화했습니다.
- `npm run build` 정상 통과 확인했습니다.
