### PR TITLE
feature: 홈 화면 캘린더/플로팅 버튼 연결 및 지출 입력 시트 연동

### DIFF
--- a/src/components/CalendarDetail.vue
+++ b/src/components/CalendarDetail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { Plus } from 'lucide-vue-next'
 
 interface Expense {
   id: number // DB에 맞춰 expenseId를 id로 변경
@@ -57,19 +58,20 @@ const getCategoryIcon = (category: string) => {
 </script>
 
 <template>
-  <Transition name="fade">
-    <div
-      v-if="isOpen"
-      class="fixed inset-0 bg-secondary/30 backdrop-blur-[2px] z-[55]"
-      @click="emit('close')"
-    ></div>
-  </Transition>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 bg-secondary/30 backdrop-blur-[2px] z-[55]"
+        @click="emit('close')"
+      ></div>
+    </Transition>
 
-  <Transition name="slide-up">
-    <div
-      v-if="isOpen"
-      class="fixed inset-x-0 bottom-0 z-[60] bg-surface-container-lowest rounded-t-[2.5rem] shadow-[0_-12px_60px_rgba(45,41,38,0.15)] h-[85vh] overflow-y-auto flex flex-col border-t border-outline-variant max-w-md mx-auto"
-    >
+    <Transition name="slide-up">
+      <div
+        v-if="isOpen"
+        class="calendar-detail-sheet fixed bottom-0 left-1/2 z-[60] flex h-[85vh] w-full max-w-md flex-col overflow-y-auto rounded-t-[2.5rem] border-t border-outline-variant bg-surface-container-lowest shadow-[0_-12px_60px_rgba(45,41,38,0.15)]"
+      >
       <div
         class="w-full flex justify-center py-4 shrink-0 sticky top-0 bg-surface-container-lowest z-10"
       >
@@ -97,7 +99,7 @@ const getCategoryIcon = (category: string) => {
             @click="emit('add-expense')"
             class="bg-primary text-on-primary w-12 h-12 rounded-2xl active:scale-95 transition-transform flex items-center justify-center shadow-lg shadow-primary/30"
           >
-            <span class="material-symbols-outlined text-[26px] font-bold">add</span>
+            <Plus :size="24" :stroke-width="2.5" aria-hidden="true" />
           </button>
         </div>
 
@@ -204,11 +206,16 @@ const getCategoryIcon = (category: string) => {
           </div>
         </section>
       </div>
-    </div>
-  </Transition>
+      </div>
+    </Transition>
+  </Teleport>
 </template>
 
 <style scoped>
+.calendar-detail-sheet {
+  transform: translateX(-50%) translateY(var(--calendar-detail-offset, 0));
+}
+
 .slide-up-enter-active {
   transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
   /* opacity 0.55s ease-out; */
@@ -221,12 +228,12 @@ const getCategoryIcon = (category: string) => {
 
 .slide-up-enter-from,
 .slide-up-leave-to {
-  transform: translateX(-50%) translateY(120%);
+  --calendar-detail-offset: 120%;
 }
 
 .slide-up-enter-to,
 .slide-up-leave-from {
-  transform: translateX(-50%) translateY(0);
+  --calendar-detail-offset: 0;
   /* opacity: 1; */
 }
 .fade-enter-active {

--- a/src/components/ExpenseInput.vue
+++ b/src/components/ExpenseInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import dayjs from 'dayjs'
 import { ChevronDown, ChevronLeft, ChevronRight, Info, X } from 'lucide-vue-next'
 
@@ -73,6 +73,8 @@ const amountError = ref('')
 const date = ref(props.selectedDate)
 const time = ref(getLocalTime())
 const currentCalendarMonth = ref(dayjs(props.selectedDate || dayjs().format('YYYY-MM-DD')).startOf('month'))
+const hourWheelRef = ref<HTMLElement | null>(null)
+const minuteWheelRef = ref<HTMLElement | null>(null)
 
 // ==========================================
 // 4. Watchers
@@ -137,16 +139,30 @@ const calendarDays = computed(() => {
   })
 })
 
-const timeSlots = computed(() =>
-  Array.from({ length: 48 }, (_, index) => {
-    const hour = String(Math.floor(index / 2)).padStart(2, '0')
-    const minute = index % 2 === 0 ? '00' : '30'
-    const value = `${hour}:${minute}`
+const selectedHour = computed(() => time.value.split(':')[0] || '00')
+
+const selectedMinute = computed(() => time.value.split(':')[1] || '00')
+
+const hourOptions = computed(() =>
+  Array.from({ length: 24 }, (_, index) => {
+    const value = String(index).padStart(2, '0')
 
     return {
       value,
-      label: formatDisplayTime(value),
-      isSelected: value === time.value,
+      label: value,
+      isSelected: value === selectedHour.value,
+    }
+  }),
+)
+
+const minuteOptions = computed(() =>
+  Array.from({ length: 60 }, (_, index) => {
+    const value = String(index).padStart(2, '0')
+
+    return {
+      value,
+      label: value,
+      isSelected: value === selectedMinute.value,
     }
   }),
 )
@@ -197,10 +213,14 @@ const toggleDatePicker = () => {
   isDatePickerOpen.value = !isDatePickerOpen.value
 }
 
-const toggleTimePicker = () => {
+const toggleTimePicker = async () => {
   isCategoryOpen.value = false
   isDatePickerOpen.value = false
   isTimePickerOpen.value = !isTimePickerOpen.value
+
+  if (isTimePickerOpen.value) {
+    await syncTimeWheelPosition()
+  }
 }
 
 const changeCalendarMonth = (step: number) => {
@@ -213,9 +233,43 @@ const selectDateFromCalendar = (isoDate: string) => {
   isDatePickerOpen.value = false
 }
 
-const selectTimeSlot = (value: string) => {
-  time.value = value
+const updateTimeValue = (nextHour: string, nextMinute: string) => {
+  time.value = `${nextHour}:${nextMinute}`
+}
+
+const selectHour = async (value: string) => {
+  updateTimeValue(value, selectedMinute.value)
+  await syncTimeWheelPosition()
+}
+
+const selectMinute = async (value: string) => {
+  updateTimeValue(selectedHour.value, value)
+  await syncTimeWheelPosition()
+}
+
+const closeTimePicker = () => {
   isTimePickerOpen.value = false
+}
+
+const scrollWheelToSelected = (container: HTMLElement | null) => {
+  if (!container) return
+
+  const selectedOption = container.querySelector<HTMLElement>('[data-selected="true"]')
+  if (!selectedOption) return
+
+  const offset =
+    selectedOption.offsetTop - container.clientHeight / 2 + selectedOption.clientHeight / 2
+
+  container.scrollTo({
+    top: Math.max(offset, 0),
+    behavior: 'smooth',
+  })
+}
+
+const syncTimeWheelPosition = async () => {
+  await nextTick()
+  scrollWheelToSelected(hourWheelRef.value)
+  scrollWheelToSelected(minuteWheelRef.value)
 }
 
 const handleSave = () => {
@@ -419,17 +473,50 @@ const handleSave = () => {
 
               <Transition name="fade-slide">
                 <div v-if="isTimePickerOpen" class="picker-panel">
-                  <div class="time-slot-grid">
-                    <button
-                      v-for="slot in timeSlots"
-                      :key="slot.value"
-                      type="button"
-                      class="time-slot-button"
-                      :class="{ 'is-selected': slot.isSelected }"
-                      @click="selectTimeSlot(slot.value)"
-                    >
-                      {{ slot.label }}
+                  <div class="time-wheel-header">
+                    <div>
+                      <p class="time-wheel-caption">시간 선택</p>
+                      <p class="time-wheel-value">{{ formatDisplayTime(time) }}</p>
+                    </div>
+                    <button type="button" class="time-wheel-done" @click="closeTimePicker">
+                      완료
                     </button>
+                  </div>
+
+                  <div class="time-wheel-layout">
+                    <div class="time-wheel-column">
+                      <span class="time-wheel-unit">시</span>
+                      <div ref="hourWheelRef" class="time-wheel-list">
+                        <button
+                          v-for="hour in hourOptions"
+                          :key="hour.value"
+                          type="button"
+                          class="wheel-option"
+                          :class="{ 'is-selected': hour.isSelected }"
+                          :data-selected="hour.isSelected"
+                          @click="selectHour(hour.value)"
+                        >
+                          {{ hour.label }}
+                        </button>
+                      </div>
+                    </div>
+
+                    <div class="time-wheel-column">
+                      <span class="time-wheel-unit">분</span>
+                      <div ref="minuteWheelRef" class="time-wheel-list">
+                        <button
+                          v-for="minute in minuteOptions"
+                          :key="minute.value"
+                          type="button"
+                          class="wheel-option"
+                          :class="{ 'is-selected': minute.isSelected }"
+                          :data-selected="minute.isSelected"
+                          @click="selectMinute(minute.value)"
+                        >
+                          {{ minute.label }}
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </Transition>
@@ -865,33 +952,124 @@ const handleSave = () => {
   user-select: none;
 }
 
-.time-slot-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.55rem;
-  max-height: 15rem;
-  overflow-y: auto;
+.time-wheel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.9rem;
 }
 
-.time-slot-button {
-  min-height: 2.65rem;
-  border-radius: 0.9rem;
-  padding: 0.55rem 0.4rem;
-  background: rgba(255, 188, 80, 0.08);
-  color: var(--color-secondary);
-  font-size: 0.83rem;
+.time-wheel-caption {
+  margin: 0;
+  font-size: 0.72rem;
   font-weight: 700;
+  color: var(--color-on-surface-variant);
+}
+
+.time-wheel-value {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: var(--color-secondary);
+  letter-spacing: -0.03em;
+}
+
+.time-wheel-done {
+  min-width: 3.5rem;
+  height: 2rem;
+  padding: 0 0.85rem;
+  border-radius: 9999px;
+  background: rgba(255, 188, 80, 0.18);
+  color: var(--color-secondary);
+  font-size: 0.78rem;
+  font-weight: 800;
   transition:
     transform 0.15s ease,
-    background-color 0.15s ease,
-    color 0.15s ease;
+    background-color 0.15s ease;
 }
 
-.time-slot-button.is-selected {
-  background: var(--color-primary);
+.time-wheel-done:active {
+  transform: scale(0.97);
 }
 
-.time-slot-button:active {
+.time-wheel-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.time-wheel-column {
+  position: relative;
+  border-radius: 1rem;
+  background: rgba(255, 188, 80, 0.08);
+  padding: 0.65rem 0.55rem;
+}
+
+.time-wheel-column::after {
+  content: '';
+  position: absolute;
+  left: 0.55rem;
+  right: 0.55rem;
+  top: 50%;
+  height: 2.75rem;
+  transform: translateY(-50%);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(209, 198, 184, 0.55);
+  pointer-events: none;
+}
+
+.time-wheel-unit {
+  display: inline-flex;
+  margin-bottom: 0.55rem;
+  padding-left: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--color-on-surface-variant);
+}
+
+.time-wheel-list {
+  position: relative;
+  z-index: 1;
+  max-height: 11.5rem;
+  overflow-y: auto;
+  padding: 4rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  scroll-snap-type: y proximity;
+  scrollbar-width: none;
+}
+
+.time-wheel-list::-webkit-scrollbar {
+  display: none;
+}
+
+.wheel-option {
+  min-height: 2.75rem;
+  border-radius: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(86, 72, 56, 0.55);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  transition:
+    transform 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+  scroll-snap-align: center;
+}
+
+.wheel-option.is-selected {
+  color: var(--color-secondary);
+  font-size: 1.08rem;
+  font-weight: 800;
+}
+
+.wheel-option:active {
   transform: scale(0.97);
 }
 

--- a/src/components/ExpenseInput.vue
+++ b/src/components/ExpenseInput.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import dayjs from 'dayjs'
+import { ChevronDown, ChevronLeft, ChevronRight, Info, X } from 'lucide-vue-next'
 
 // ==========================================
 // 1. 타입 정의 (DB 카테고리와 완벽 일치)
@@ -56,6 +58,8 @@ const getLocalTime = () => {
   return now.toTimeString().slice(0, 5)
 }
 
+const CALENDAR_WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
 // ==========================================
 // 3. 상태 관리 (State)
 // ==========================================
@@ -63,9 +67,12 @@ const amount = ref('0')
 const category = ref<Category>('일반식사')
 const memo = ref('')
 const isCategoryOpen = ref(false)
+const isDatePickerOpen = ref(false)
+const isTimePickerOpen = ref(false)
 const amountError = ref('')
 const date = ref(props.selectedDate)
 const time = ref(getLocalTime())
+const currentCalendarMonth = ref(dayjs(props.selectedDate || dayjs().format('YYYY-MM-DD')).startOf('month'))
 
 // ==========================================
 // 4. Watchers
@@ -80,7 +87,10 @@ watch(
       category.value = '일반식사'
       memo.value = ''
       isCategoryOpen.value = false
+      isDatePickerOpen.value = false
+      isTimePickerOpen.value = false
       amountError.value = ''
+      currentCalendarMonth.value = dayjs(props.selectedDate).startOf('month')
     }
   },
 )
@@ -89,6 +99,7 @@ watch(
   () => props.selectedDate,
   (newDate) => {
     date.value = newDate
+    currentCalendarMonth.value = dayjs(newDate).startOf('month')
   },
 )
 
@@ -98,6 +109,47 @@ watch(
 const currentCategoryIcon = computed(() => {
   return CATEGORIES.find((c) => c.name === category.value)?.icon || '/images/categories/meal.png'
 })
+
+const calendarMonthLabel = computed(() => currentCalendarMonth.value.format('YYYY. MM'))
+
+const calendarDays = computed(() => {
+  const monthStart = currentCalendarMonth.value.startOf('month')
+  const monthEnd = currentCalendarMonth.value.endOf('month')
+  const startOffset = monthStart.day()
+  const endOffset = 6 - monthEnd.day()
+  const calendarStart = monthStart.subtract(startOffset, 'day')
+  const calendarEnd = monthEnd.add(endOffset, 'day')
+  const totalDays = calendarEnd.diff(calendarStart, 'day') + 1
+  const totalCells = totalDays <= 35 ? 35 : 42
+
+  return Array.from({ length: totalCells }, (_, index) => {
+    const nextDate = calendarStart.add(index, 'day')
+    const isoDate = nextDate.format('YYYY-MM-DD')
+
+    return {
+      key: `${isoDate}-${index}`,
+      isoDate,
+      label: nextDate.date(),
+      inCurrentMonth: nextDate.month() === currentCalendarMonth.value.month(),
+      isSelected: isoDate === date.value,
+      isToday: nextDate.isSame(dayjs(), 'day'),
+    }
+  })
+})
+
+const timeSlots = computed(() =>
+  Array.from({ length: 48 }, (_, index) => {
+    const hour = String(Math.floor(index / 2)).padStart(2, '0')
+    const minute = index % 2 === 0 ? '00' : '30'
+    const value = `${hour}:${minute}`
+
+    return {
+      value,
+      label: formatDisplayTime(value),
+      isSelected: value === time.value,
+    }
+  }),
+)
 
 // ==========================================
 // 6. Methods
@@ -125,6 +177,45 @@ const formatDisplayTime = (timeStr: string) => {
   const period = hour >= 12 ? '오후' : '오전'
   const displayHour = hour % 12 || 12
   return `${period} ${displayHour}:${m}`
+}
+
+const selectCategory = (value: Category) => {
+  category.value = value
+  isCategoryOpen.value = false
+}
+
+const toggleCategory = () => {
+  isDatePickerOpen.value = false
+  isTimePickerOpen.value = false
+  isCategoryOpen.value = !isCategoryOpen.value
+}
+
+const toggleDatePicker = () => {
+  isCategoryOpen.value = false
+  isTimePickerOpen.value = false
+  currentCalendarMonth.value = dayjs(date.value).startOf('month')
+  isDatePickerOpen.value = !isDatePickerOpen.value
+}
+
+const toggleTimePicker = () => {
+  isCategoryOpen.value = false
+  isDatePickerOpen.value = false
+  isTimePickerOpen.value = !isTimePickerOpen.value
+}
+
+const changeCalendarMonth = (step: number) => {
+  currentCalendarMonth.value = currentCalendarMonth.value.add(step, 'month').startOf('month')
+}
+
+const selectDateFromCalendar = (isoDate: string) => {
+  date.value = isoDate
+  currentCalendarMonth.value = dayjs(isoDate).startOf('month')
+  isDatePickerOpen.value = false
+}
+
+const selectTimeSlot = (value: string) => {
+  time.value = value
+  isTimePickerOpen.value = false
 }
 
 const handleSave = () => {
@@ -163,7 +254,7 @@ const handleSave = () => {
           <div class="sheet-header">
             <h2 class="sheet-title">지출 내역 입력</h2>
             <button @click="emit('close')" class="close-button">
-              <span class="material-symbols-outlined" style="font-size: 20px">close</span>
+              <X :size="20" aria-hidden="true" />
             </button>
           </div>
 
@@ -180,7 +271,7 @@ const handleSave = () => {
 
           <div class="form-fields">
             <div class="field-container">
-              <button @click="isCategoryOpen = !isCategoryOpen" class="field-button" type="button">
+              <button @click="toggleCategory" class="field-button" type="button">
                 <div class="field-left">
                   <div class="field-icon">
                     <img :src="currentCategoryIcon" alt="카테고리" class="w-6 h-6 object-contain" />
@@ -189,13 +280,12 @@ const handleSave = () => {
                 </div>
                 <div class="field-right">
                   <span class="field-value">{{ category }}</span>
-                  <span
-                    class="material-symbols-outlined chevron"
+                  <ChevronDown
+                    aria-hidden="true"
+                    :size="20"
+                    class="chevron"
                     :class="{ 'rotate-180': isCategoryOpen }"
-                    style="font-size: 20px"
-                  >
-                    expand_more
-                  </span>
+                  />
                 </div>
               </button>
 
@@ -205,10 +295,7 @@ const handleSave = () => {
                     <button
                       v-for="cat in CATEGORIES"
                       :key="cat.name"
-                      @click="
-                        category = cat.name
-                        isCategoryOpen = false
-                      "
+                      @click="selectCategory(cat.name)"
                       class="dropdown-item"
                       type="button"
                     >
@@ -222,44 +309,130 @@ const handleSave = () => {
               </Transition>
             </div>
 
-            <div class="field-row">
-              <div class="field-left">
-                <div class="field-icon">
-                  <img src="/images/action/date.png" alt="날짜" class="w-6 h-6 object-contain" />
+            <div class="field-container field-container--stack">
+              <div
+                class="field-row field-row--picker"
+                role="button"
+                tabindex="0"
+                @click="toggleDatePicker"
+                @keydown.enter.prevent="toggleDatePicker"
+                @keydown.space.prevent="toggleDatePicker"
+              >
+                <div class="field-left">
+                  <div class="field-icon">
+                    <img src="/images/action/date.png" alt="날짜" class="w-6 h-6 object-contain" />
+                  </div>
+                  <span class="field-label">날짜</span>
                 </div>
-                <span class="field-label">날짜</span>
-              </div>
-              <div class="field-input-wrapper">
-                <input
-                  type="date"
-                  v-model="date"
-                  class="hidden-input"
-                  style="color-scheme: light"
-                />
-                <div class="display-box">
-                  {{ formatDisplayDate(date) }}
+                <div class="field-right">
+                  <div class="display-box">
+                    {{ formatDisplayDate(date) }}
+                  </div>
+                  <ChevronDown
+                    aria-hidden="true"
+                    :size="20"
+                    class="chevron"
+                    :class="{ 'rotate-180': isDatePickerOpen }"
+                  />
                 </div>
               </div>
+
+              <Transition name="fade-slide">
+                <div v-if="isDatePickerOpen" class="picker-panel">
+                  <div class="picker-panel-header">
+                    <button
+                      type="button"
+                      class="picker-nav-button"
+                      aria-label="이전 달"
+                      @click="changeCalendarMonth(-1)"
+                    >
+                      <ChevronLeft :size="18" aria-hidden="true" />
+                    </button>
+                    <p class="picker-panel-title">{{ calendarMonthLabel }}</p>
+                    <button
+                      type="button"
+                      class="picker-nav-button"
+                      aria-label="다음 달"
+                      @click="changeCalendarMonth(1)"
+                    >
+                      <ChevronRight :size="18" aria-hidden="true" />
+                    </button>
+                  </div>
+
+                  <div class="calendar-weekdays">
+                    <span
+                      v-for="weekday in CALENDAR_WEEKDAYS"
+                      :key="weekday"
+                      class="calendar-weekday"
+                    >
+                      {{ weekday }}
+                    </span>
+                  </div>
+
+                  <div class="calendar-grid">
+                    <button
+                      v-for="day in calendarDays"
+                      :key="day.key"
+                      type="button"
+                      class="calendar-day-button"
+                      :class="{
+                        'is-muted': !day.inCurrentMonth,
+                        'is-selected': day.isSelected,
+                        'is-today': day.isToday,
+                      }"
+                      @click="selectDateFromCalendar(day.isoDate)"
+                    >
+                      {{ day.label }}
+                    </button>
+                  </div>
+                </div>
+              </Transition>
             </div>
 
-            <div class="field-row">
-              <div class="field-left">
-                <div class="field-icon">
-                  <img src="/images/action/time.png" alt="시간" class="w-6 h-6 object-contain" />
+            <div class="field-container field-container--stack">
+              <div
+                class="field-row field-row--picker"
+                role="button"
+                tabindex="0"
+                @click="toggleTimePicker"
+                @keydown.enter.prevent="toggleTimePicker"
+                @keydown.space.prevent="toggleTimePicker"
+              >
+                <div class="field-left">
+                  <div class="field-icon">
+                    <img src="/images/action/time.png" alt="시간" class="w-6 h-6 object-contain" />
+                  </div>
+                  <span class="field-label">시간</span>
                 </div>
-                <span class="field-label">시간</span>
-              </div>
-              <div class="field-input-wrapper">
-                <input
-                  type="time"
-                  v-model="time"
-                  class="hidden-input"
-                  style="color-scheme: light"
-                />
-                <div class="display-box">
-                  {{ formatDisplayTime(time) }}
+                <div class="field-right">
+                  <div class="display-box">
+                    {{ formatDisplayTime(time) }}
+                  </div>
+                  <ChevronDown
+                    aria-hidden="true"
+                    :size="20"
+                    class="chevron"
+                    :class="{ 'rotate-180': isTimePickerOpen }"
+                  />
                 </div>
               </div>
+
+              <Transition name="fade-slide">
+                <div v-if="isTimePickerOpen" class="picker-panel">
+                  <div class="time-slot-grid">
+                    <button
+                      v-for="slot in timeSlots"
+                      :key="slot.value"
+                      type="button"
+                      class="time-slot-button"
+                      :class="{ 'is-selected': slot.isSelected }"
+                      @click="selectTimeSlot(slot.value)"
+                    >
+                      {{ slot.label }}
+                    </button>
+                  </div>
+                </div>
+              </Transition>
             </div>
 
             <div class="memo-section">
@@ -278,7 +451,7 @@ const handleSave = () => {
           </div>
 
           <div class="notice-box">
-            <span class="material-symbols-outlined notice-icon" style="font-size: 20px">info</span>
+            <Info :size="18" class="notice-icon" aria-hidden="true" />
             <p class="notice-text">
               지출 등록 시
               <span class="notice-highlight">투자 가능 금액</span>과
@@ -454,6 +627,12 @@ const handleSave = () => {
   position: relative;
 }
 
+.field-container--stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .field-button,
 .field-row {
   width: 100%;
@@ -469,6 +648,15 @@ const handleSave = () => {
 .field-button:hover,
 .field-row:hover {
   background-color: var(--color-surface-container-low);
+}
+
+.field-row--picker {
+  cursor: pointer;
+}
+
+.field-row--picker:focus-visible {
+  outline: 2px solid rgba(255, 188, 80, 0.5);
+  outline-offset: 2px;
 }
 
 .field-left {
@@ -568,24 +756,102 @@ const handleSave = () => {
   justify-content: center;
 }
 
-.field-input-wrapper {
-  position: relative;
-  color: var(--color-on-surface-variant); /* kb-brown-light 수정 */
+.picker-panel {
+  border: 1px solid rgba(209, 198, 184, 0.7);
+  background: #fffdf8;
+  border-radius: 1rem;
+  box-shadow:
+    0 14px 28px -18px rgba(42, 34, 24, 0.28),
+    0 8px 12px -10px rgba(42, 34, 24, 0.16);
+  padding: 0.9rem;
 }
 
-.hidden-input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0.001;
-  border: none;
+.picker-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+}
+
+.picker-panel-title {
+  margin: 0;
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.picker-nav-button {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-secondary);
+  background: rgba(255, 188, 80, 0.14);
+  transition:
+    transform 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.picker-nav-button:hover {
+  background: rgba(255, 188, 80, 0.22);
+}
+
+.picker-nav-button:active {
+  transform: scale(0.96);
+}
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.calendar-weekday {
+  text-align: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--color-on-surface-variant);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.25rem;
+}
+
+.calendar-day-button {
+  aspect-ratio: 1;
+  border-radius: 0.9rem;
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: var(--color-secondary);
   background: transparent;
-  color: transparent;
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: pointer;
-  z-index: 20;
+  transition:
+    transform 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.calendar-day-button.is-muted {
+  color: rgba(112, 99, 84, 0.42);
+}
+
+.calendar-day-button.is-today {
+  box-shadow: inset 0 0 0 1px rgba(255, 188, 80, 0.5);
+}
+
+.calendar-day-button.is-selected {
+  background: var(--color-primary);
+  color: var(--color-secondary);
+}
+
+.calendar-day-button:active {
+  transform: scale(0.95);
 }
 
 .display-box {
@@ -596,6 +862,37 @@ const handleSave = () => {
   font-size: 0.875rem;
   font-weight: 600;
   transition: transform 0.1s;
+  user-select: none;
+}
+
+.time-slot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+  max-height: 15rem;
+  overflow-y: auto;
+}
+
+.time-slot-button {
+  min-height: 2.65rem;
+  border-radius: 0.9rem;
+  padding: 0.55rem 0.4rem;
+  background: rgba(255, 188, 80, 0.08);
+  color: var(--color-secondary);
+  font-size: 0.83rem;
+  font-weight: 700;
+  transition:
+    transform 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.time-slot-button.is-selected {
+  background: var(--color-primary);
+}
+
+.time-slot-button:active {
+  transform: scale(0.97);
 }
 
 .display-box:active {
@@ -758,5 +1055,24 @@ const handleSave = () => {
 .fade-enter-to,
 .fade-leave-from {
   opacity: 1;
+}
+
+.fade-slide-enter-active,
+.fade-slide-leave-active {
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.fade-slide-enter-from,
+.fade-slide-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.fade-slide-enter-to,
+.fade-slide-leave-from {
+  opacity: 1;
+  transform: translateY(0);
 }
 </style>

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -3,6 +3,8 @@ import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
 import { toast } from 'vue3-toastify'
 import HoneyPot from '@/components/HoneyPot.vue'
+import CalendarDetail from '@/components/CalendarDetail.vue'
+import ExpenseInput from '@/components/ExpenseInput.vue'
 import { useHoneyPot } from '@/composables/useHoneyPot'
 
 const weekdays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
@@ -31,6 +33,51 @@ const calendarAccentMap = {
 
 const currentMonth = ref(dayjs('2024-05-01'))
 const selectedDate = ref(dayjs('2024-05-03'))
+const isCalendarDetailOpen = ref(false)
+const isExpenseInputOpen = ref(false)
+const reopenCalendarDetail = ref(false)
+const expenseEntries = ref([
+  {
+    id: 1,
+    category: '카페/음료',
+    amount: 4800,
+    date: '2024-05-02',
+    time: '08:40',
+    memo: '출근 전 아메리카노',
+  },
+  {
+    id: 2,
+    category: '일반식사',
+    amount: 11000,
+    date: '2024-05-02',
+    time: '12:15',
+    memo: '점심 식사',
+  },
+  {
+    id: 3,
+    category: '카페/음료',
+    amount: 5400,
+    date: '2024-05-03',
+    time: '09:10',
+    memo: '아이스 라떼',
+  },
+  {
+    id: 4,
+    category: '일반식사',
+    amount: 10200,
+    date: '2024-05-03',
+    time: '12:20',
+    memo: '회사 앞 점심',
+  },
+  {
+    id: 5,
+    category: '쇼핑',
+    amount: 10000,
+    date: '2024-05-03',
+    time: '19:40',
+    memo: '생활용품 구매',
+  },
+])
 
 const historyItems = [
   {
@@ -202,6 +249,21 @@ const { displayPercentage, fillPercentage, guidelinePercentage } = useHoneyPot(8
 const visibleHistoryCount = ref(3)
 const recentItems = computed(() => historyItems.slice(0, visibleHistoryCount.value))
 const canLoadMoreHistory = computed(() => visibleHistoryCount.value < historyItems.length)
+const selectedDateKey = computed(() => selectedDate.value.format('YYYY-MM-DD'))
+const selectedDayExpenses = computed(() =>
+  expenseEntries.value.filter((expense) => expense.date === selectedDateKey.value),
+)
+const calendarDailyReport = computed(() => {
+  const stockPrice = 47900
+  const totalSpent = selectedDayExpenses.value.reduce((sum, expense) => sum + expense.amount, 0)
+
+  return {
+    securedQuantity: Number((totalSpent / stockPrice).toFixed(2)),
+    stockName: '카카오',
+    savedAmount: Math.max(0, stockPrice - totalSpent),
+    progressRate: Math.min(100, Math.round((totalSpent / stockPrice) * 100)),
+  }
+})
 
 const calendarDays = computed(() => {
   const monthStart = currentMonth.value.startOf('month')
@@ -263,6 +325,53 @@ function handleStockClick() {
 
 function loadMoreHistory() {
   visibleHistoryCount.value = Math.min(historyItems.length, visibleHistoryCount.value + 10)
+}
+
+function openCalendarDetail(isoDate) {
+  selectDate(isoDate)
+  isCalendarDetailOpen.value = true
+}
+
+function closeCalendarDetail() {
+  isCalendarDetailOpen.value = false
+}
+
+function showExpenseInput() {
+  reopenCalendarDetail.value = false
+  isExpenseInputOpen.value = true
+}
+
+function openExpenseInputFromCalendar() {
+  reopenCalendarDetail.value = true
+  isCalendarDetailOpen.value = false
+  isExpenseInputOpen.value = true
+}
+
+function closeExpenseInput() {
+  isExpenseInputOpen.value = false
+
+  if (reopenCalendarDetail.value) {
+    isCalendarDetailOpen.value = true
+    reopenCalendarDetail.value = false
+  }
+}
+
+function handleExpenseSave(payload) {
+  expenseEntries.value = [
+    {
+      id: Date.now(),
+      amount: payload.amount,
+      category: payload.category,
+      date: payload.date,
+      time: payload.time,
+      memo: payload.memo || '직접 입력',
+    },
+    ...expenseEntries.value,
+  ]
+
+  toast.success('지출이 추가됐어요.', {
+    autoClose: 1600,
+  })
 }
 </script>
 
@@ -341,7 +450,7 @@ function loadMoreHistory() {
                   'is-today': day.isToday,
                 }"
                 :aria-pressed="day.isSelected"
-                @click="selectDate(day.isoDate)"
+                @click="openCalendarDetail(day.isoDate)"
               >
                 <span class="calendar-day">{{ day.label }}</span>
                 <span v-if="day.dotTone" class="calendar-dot" :class="`tone-${day.dotTone}`"></span>
@@ -390,9 +499,25 @@ function loadMoreHistory() {
           </button>
         </section>
 
-        <button class="floating-action" type="button" aria-label="추가" @click="handleAddClick">
+        <button class="floating-action" type="button" aria-label="추가" @click="showExpenseInput">
           <span class="floating-action-icon" aria-hidden="true"></span>
         </button>
+
+        <CalendarDetail
+          :is-open="isCalendarDetailOpen"
+          :selected-date="selectedDateKey"
+          :day-expenses="selectedDayExpenses"
+          :daily-report="calendarDailyReport"
+          @close="closeCalendarDetail"
+          @add-expense="openExpenseInputFromCalendar"
+        />
+
+        <ExpenseInput
+          :is-open="isExpenseInputOpen"
+          :selected-date="selectedDateKey"
+          @close="closeExpenseInput"
+          @save="handleExpenseSave"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 🚀 PR 개요
- 작업 내용 요약:
  홈 화면에서 캘린더 날짜 클릭과 하단 플로팅 `+` 버튼 클릭 시, 기존 페이지 이동이 아니라 바텀시트 형태로 상세/입력 UI가 열리도록 연결했습니다.
  또한 지출 입력 시트에서 날짜는 커스텀 캘린더, 시간은 휠형 UI로 선택할 수 있도록 개선했습니다.
- 관련 이슈: #38

---

## ✨ 변경 사항
- 홈 화면 날짜 클릭 시 `CalendarDetail` 바텀시트가 열리도록 연결
- 홈 화면 플로팅 `+` 버튼 클릭 시 `ExpenseInput` 바텀시트가 열리도록 연결
- 지출 입력 시트에서 날짜는 커스텀 캘린더, 시간은 휠형 선택 UI로 커스텀 적용

---

## 🧩 작업 유형
- [ ] 🐛 Bug Fix
- [x] ✨ Feature
- [ ] 🔧 Refactor
- [x] 🎨 UI/UX
- [ ] 🔌 API
- [ ] ⚡ Performance
- [ ] ⚙️ Config / Build

---

## 📍 주요 변경 파일
- `src/pages/homePage/HomePage.vue`
- `src/components/CalendarDetail.vue`
- `src/components/ExpenseInput.vue`

---

## 🖼️ 스크린샷 (선택)
> UI 변경 시 필수

- 홈 화면에서 날짜 클릭 시 캘린더 상세 시트가 올라오는 화면
- 홈 화면에서 `+` 버튼 클릭 시 지출 입력 시트가 올라오는 화면
- 지출 입력 시트에서 날짜 커스텀 캘린더와 시간 휠형 UI가 보이는 화면

---

## 🧪 테스트 방법
1. `npm run dev` 실행 후 `/home` 진입
2. 캘린더 날짜 클릭 시 `CalendarDetail` 시트가 열리고, `+` 버튼 클릭 시 `ExpenseInput` 시트가 열리는지 확인
3. 지출 입력 시트에서 날짜/시간 선택 후 저장, 그리고 `npm run build` 정상 통과 여부 확인

---

## ⚠️ 체크리스트
- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 기존 기능 영향 없음
- [x] 반응형/UI 확인 (필요 시)

---

## 💬 기타 사항
- 시간 선택 UI는 초기 슬롯형에서 휠형 UI로 한 번 더 개선했습니다.
- 홈 화면 내 기존 컴포넌트 구조를 최대한 유지하면서 연결 중심으로 작업했습니다.
- `npm run build` 정상 통과 확인했습니다.
