### PR TITLE
feat: Pinia 도입 및 예산/지출 전역 상태 관리 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "dayjs": "^1.11.13",
         "lucide-vue-next": "^1.0.0",
         "motion": "^12.38.0",
-        "pinia": "^3.0.1",
+        "pinia": "^3.0.4",
         "tailwindcss": "^4.2.2",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dayjs": "^1.11.13",
     "lucide-vue-next": "^1.0.0",
     "motion": "^12.38.0",
-    "pinia": "^3.0.1",
+    "pinia": "^3.0.4",
     "tailwindcss": "^4.2.2",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",

--- a/src/components/CalendarDetail.vue
+++ b/src/components/CalendarDetail.vue
@@ -23,6 +23,7 @@ interface Props {
     stockName: string
     savedAmount: number
     progressRate: number
+    isSaved: boolean
   }
 }
 
@@ -72,142 +73,155 @@ const getCategoryIcon = (category: string) => {
         v-if="isOpen"
         class="calendar-detail-sheet fixed bottom-0 left-1/2 z-[60] flex h-[85vh] w-full max-w-md flex-col overflow-y-auto rounded-t-[2.5rem] border-t border-outline-variant bg-surface-container-lowest shadow-[0_-12px_60px_rgba(45,41,38,0.15)]"
       >
-      <div
-        class="w-full flex justify-center py-4 shrink-0 sticky top-0 bg-surface-container-lowest z-10"
-      >
-        <div class="w-10 h-1.5 bg-surface-container-highest rounded-full"></div>
-      </div>
-
-      <div class="px-6 pb-32">
-        <div class="flex justify-between items-start mb-6">
-          <div>
-            <p
-              class="text-on-surface-variant text-[12px] font-bold tracking-wider mb-1 uppercase font-label"
-            >
-              일일 요약
-            </p>
-            <h3 class="text-2xl font-extrabold font-headline text-on-surface tracking-tight">
-              {{ formattedDate }}
-            </h3>
-            <div class="flex items-center gap-1.5 mt-1.5">
-              <span class="text-[13px] font-extrabold text-primary tracking-tight font-label"
-                >오늘의 절약 리포트</span
-              >
-            </div>
-          </div>
-          <button
-            @click="emit('add-expense')"
-            class="bg-primary text-on-primary w-12 h-12 rounded-2xl active:scale-95 transition-transform flex items-center justify-center shadow-lg shadow-primary/30"
-          >
-            <Plus :size="24" :stroke-width="2.5" aria-hidden="true" />
-          </button>
+        <div
+          class="w-full flex justify-center py-4 shrink-0 sticky top-0 bg-surface-container-lowest z-10"
+        >
+          <div class="w-10 h-1.5 bg-surface-container-highest rounded-full"></div>
         </div>
 
-        <div class="mb-6">
-          <div
-            class="bg-surface-container-low border border-outline-variant p-6 rounded-[2.5rem] relative overflow-hidden"
-          >
-            <div class="absolute -right-4 -bottom-4 w-32 h-32 opacity-20 pointer-events-none">
-              <div class="honey-pot-mask relative w-full h-full bg-outline-variant overflow-hidden">
+        <div class="px-6 pb-32">
+          <div class="flex justify-between items-start mb-6">
+            <div>
+              <p
+                class="text-on-surface-variant text-[12px] font-bold tracking-wider mb-1 uppercase font-label"
+              >
+                일일 요약
+              </p>
+              <h3 class="text-2xl font-extrabold font-headline text-on-surface tracking-tight">
+                {{ formattedDate }}
+              </h3>
+              <div class="flex items-center gap-1.5 mt-1.5">
+                <span class="text-[13px] font-extrabold text-primary tracking-tight font-label"
+                  >오늘의 절약 리포트</span
+                >
+              </div>
+            </div>
+            <button
+              @click="emit('add-expense')"
+              class="bg-primary text-on-primary w-12 h-12 rounded-2xl active:scale-95 transition-transform flex items-center justify-center shadow-lg shadow-primary/30"
+            >
+              <Plus :size="24" :stroke-width="2.5" aria-hidden="true" />
+            </button>
+          </div>
+
+          <div class="mb-6">
+            <div
+              class="bg-surface-container-low border border-outline-variant p-6 rounded-[2.5rem] relative overflow-hidden"
+            >
+              <div class="absolute -right-4 -bottom-4 w-32 h-32 opacity-20 pointer-events-none">
                 <div
-                  class="absolute bottom-0 left-0 right-0 bg-primary animate-wave origin-bottom"
-                  :style="{ height: `${dailyReport.progressRate}%` }"
+                  class="honey-pot-mask relative w-full h-full bg-outline-variant overflow-hidden"
                 >
                   <div
-                    class="absolute -top-4 left-0 right-0 h-8 bg-primary rounded-[50%] scale-x-125"
-                  ></div>
+                    class="absolute bottom-0 left-0 right-0 bg-primary animate-wave origin-bottom"
+                    :style="{ height: `${dailyReport.progressRate}%` }"
+                  >
+                    <div
+                      class="absolute -top-4 left-0 right-0 h-8 bg-primary rounded-[50%] scale-x-125"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="relative z-10">
+                <div class="flex flex-col items-start">
+                  <p class="text-on-surface-variant text-[13px] font-bold mb-2 font-label">
+                    오늘 지출은 주식으로
+                  </p>
+                  <p class="text-[32px] font-extrabold text-secondary font-headline leading-tight">
+                    {{ dailyReport.stockName }} {{ dailyReport.securedQuantity }}주
+                  </p>
+                  <p class="text-lg font-bold text-secondary font-headline">확보했습니다</p>
                 </div>
               </div>
             </div>
-
-            <div class="relative z-10">
-              <div class="flex flex-col items-start">
-                <p class="text-on-surface-variant text-[13px] font-bold mb-2 font-label">
-                  오늘 지출은 주식으로
-                </p>
-                <p class="text-[32px] font-extrabold text-secondary font-headline leading-tight">
-                  {{ dailyReport.stockName }} {{ dailyReport.securedQuantity }}주
-                </p>
-                <p class="text-lg font-bold text-secondary font-headline">확보했습니다</p>
-              </div>
-            </div>
           </div>
-        </div>
 
-        <div class="bg-surface border border-outline-variant p-5 rounded-2xl mb-10">
-          <div class="flex items-center gap-4">
-            <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
-              <img src="/images/action/money.png" alt="총 지출" class="w-6 h-6 object-contain" />
-            </div>
-            <div class="flex-1">
-              <p class="text-xs font-bold text-on-surface-variant mb-0.5 font-label">
-                오늘의 총 지출
-              </p>
-              <p class="text-2xl font-extrabold font-headline text-on-surface leading-none">
-                {{ totalAmount.toLocaleString() }}원
-              </p>
-              <div class="mt-2.5 pt-2.5 border-t border-outline-variant/40">
-                <p class="text-xs font-semibold text-on-surface-variant font-body">
-                  평균보다
-                  <span class="text-secondary font-bold"
-                    >{{ dailyReport.savedAmount.toLocaleString() }}원</span
-                  >
-                  더 아꼈어요!
-                </p>
+          <div class="bg-surface border border-outline-variant p-5 rounded-2xl mb-10">
+            <div class="flex items-center gap-4">
+              <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
+                <img src="/images/action/money.png" alt="총 지출" class="w-6 h-6 object-contain" />
               </div>
-            </div>
-          </div>
-        </div>
-
-        <section>
-          <div class="flex items-center gap-2 mb-5">
-            <img src="/images/action/list.png" alt="거래 내역" class="w-5 h-5 object-contain" />
-            <h4 class="text-[16px] font-extrabold text-on-surface tracking-tight font-headline">
-              거래 내역
-            </h4>
-          </div>
-          <div class="space-y-3">
-            <div
-              v-for="exp in dayExpenses"
-              :key="exp.id"
-              class="flex items-center gap-4 p-4 bg-surface-container-low border border-transparent hover:border-outline-variant rounded-2xl transition-all cursor-pointer"
-            >
-              <div
-                class="w-12 h-12 rounded-xl bg-surface-container-lowest border border-outline-variant flex items-center justify-center"
-              >
-                <span class="category-image-mask" aria-hidden="true">
-                  <img
-                    :src="getCategoryIcon(exp.category)"
-                    :alt="exp.category"
-                    class="category-image"
-                  />
-                </span>
-              </div>
-
               <div class="flex-1">
-                <div class="flex justify-between items-center mb-0.5">
-                  <span class="text-[15px] font-bold text-on-surface font-body">{{
-                    exp.category
-                  }}</span>
-                  <span class="text-[15px] font-extrabold font-headline text-error"
-                    >-₩{{ exp.amount.toLocaleString() }}</span
+                <p class="text-xs font-bold text-on-surface-variant mb-0.5 font-label">
+                  오늘의 총 지출
+                </p>
+                <p class="text-2xl font-extrabold font-headline text-on-surface leading-none">
+                  {{ totalAmount.toLocaleString() }}원
+                </p>
+                <div class="mt-2.5 pt-2.5 border-t border-outline-variant/40">
+                  <p
+                    v-if="dailyReport.isSaved"
+                    class="text-xs font-semibold text-on-surface-variant font-body"
                   >
+                    평균보다
+                    <span class="text-secondary font-bold"
+                      >{{ dailyReport.savedAmount.toLocaleString() }}원</span
+                    >
+                    더 아꼈어요!
+                  </p>
+
+                  <p v-else class="text-xs font-semibold text-on-surface-variant font-body">
+                    평균보다
+                    <span class="text-error font-bold"
+                      >{{ dailyReport.savedAmount.toLocaleString() }}원</span
+                    >
+                    더 썼어요 😢
+                  </p>
                 </div>
-                <div class="flex justify-between items-center">
-                  <span class="text-[13px] text-on-surface-variant font-medium font-body">{{
-                    exp.memo
-                  }}</span>
-                  <span
-                    class="text-[10px] text-on-surface-variant/60 font-bold font-headline uppercase tracking-wider"
-                  >
-                    {{ exp.time }}
+              </div>
+            </div>
+          </div>
+
+          <section>
+            <div class="flex items-center gap-2 mb-5">
+              <img src="/images/action/list.png" alt="거래 내역" class="w-5 h-5 object-contain" />
+              <h4 class="text-[16px] font-extrabold text-on-surface tracking-tight font-headline">
+                거래 내역
+              </h4>
+            </div>
+            <div class="space-y-3">
+              <div
+                v-for="exp in dayExpenses"
+                :key="exp.id"
+                class="flex items-center gap-4 p-4 bg-surface-container-low border border-transparent hover:border-outline-variant rounded-2xl transition-all cursor-pointer"
+              >
+                <div
+                  class="w-12 h-12 rounded-xl bg-surface-container-lowest border border-outline-variant flex items-center justify-center"
+                >
+                  <span class="category-image-mask" aria-hidden="true">
+                    <img
+                      :src="getCategoryIcon(exp.category)"
+                      :alt="exp.category"
+                      class="category-image"
+                    />
                   </span>
                 </div>
+
+                <div class="flex-1">
+                  <div class="flex justify-between items-center mb-0.5">
+                    <span class="text-[15px] font-bold text-on-surface font-body">{{
+                      exp.category
+                    }}</span>
+                    <span class="text-[15px] font-extrabold font-headline text-error"
+                      >-₩{{ exp.amount.toLocaleString() }}</span
+                    >
+                  </div>
+                  <div class="flex justify-between items-center">
+                    <span class="text-[13px] text-on-surface-variant font-medium font-body">{{
+                      exp.memo
+                    }}</span>
+                    <span
+                      class="text-[10px] text-on-surface-variant/60 font-bold font-headline uppercase tracking-wider"
+                    >
+                      {{ exp.time }}
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </section>
-      </div>
+          </section>
+        </div>
       </div>
     </Transition>
   </Teleport>

--- a/src/components/ExpenseInput.vue
+++ b/src/components/ExpenseInput.vue
@@ -2,7 +2,8 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import dayjs from 'dayjs'
 import { ChevronDown, ChevronLeft, ChevronRight, Info, X } from 'lucide-vue-next'
-
+import { useBudgetStore } from '@/stores/useBudgetStore'
+const budgetStore = useBudgetStore()
 // ==========================================
 // 1. 타입 정의 (DB 카테고리와 완벽 일치)
 // ==========================================
@@ -72,7 +73,9 @@ const isTimePickerOpen = ref(false)
 const amountError = ref('')
 const date = ref(props.selectedDate)
 const time = ref(getLocalTime())
-const currentCalendarMonth = ref(dayjs(props.selectedDate || dayjs().format('YYYY-MM-DD')).startOf('month'))
+const currentCalendarMonth = ref(
+  dayjs(props.selectedDate || dayjs().format('YYYY-MM-DD')).startOf('month'),
+)
 const hourWheelRef = ref<HTMLElement | null>(null)
 const minuteWheelRef = ref<HTMLElement | null>(null)
 
@@ -281,6 +284,7 @@ const handleSave = () => {
   }
   amountError.value = ''
 
+  // 원래 약속된 형식대로 5가지 데이터를 모두 담아서 부모(HomePage)에게 쏩니다!
   emit('save', {
     amount: numericAmount,
     category: category.value,
@@ -356,7 +360,10 @@ const handleSave = () => {
                       type="button"
                     >
                       <span class="dropdown-icon">
-                        <span class="category-image-mask category-image-mask--sm" aria-hidden="true">
+                        <span
+                          class="category-image-mask category-image-mask--sm"
+                          aria-hidden="true"
+                        >
                           <img :src="cat.icon" :alt="cat.name" class="category-image" />
                         </span>
                       </span>

--- a/src/components/ExpenseInput.vue
+++ b/src/components/ExpenseInput.vue
@@ -2,8 +2,7 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import dayjs from 'dayjs'
 import { ChevronDown, ChevronLeft, ChevronRight, Info, X } from 'lucide-vue-next'
-import { useBudgetStore } from '@/stores/useBudgetStore'
-const budgetStore = useBudgetStore()
+
 // ==========================================
 // 1. 타입 정의 (DB 카테고리와 완벽 일치)
 // ==========================================

--- a/src/main.js
+++ b/src/main.js
@@ -18,5 +18,4 @@ app.use(Vue3Toastify, {
   autoClose: 3000,
   position: 'top-right',
 })
-
 app.mount('#app')

--- a/src/pages/Setup/ExpenseGoalSetup.vue
+++ b/src/pages/Setup/ExpenseGoalSetup.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useRouter } from 'vue-router' // 화면 이동을 위해 추가
-import { useBudgetStore } from '@/stores/useBudgetStore' // 방금 만든 Pinia 스토어 추가
+import { useRouter } from 'vue-router'
+import { useBudgetStore } from '@/stores/useBudgetStore'
 import {
   X,
   Wallet,
@@ -15,13 +15,11 @@ import {
   Coins,
 } from 'lucide-vue-next'
 import { Motion } from '@motionone/vue'
-// 추가
-const router = useRouter()
-const budgetStore = useBudgetStore() // 스토어 인스턴스 생성
 
+const router = useRouter()
+const budgetStore = useBudgetStore()
 
 const lastMonthExpense = ref('')
-const router = useRouter()
 const onExpenseInput = (e) => {
   const value = e.target.value.replace(/[^0-9]/g, '')
   lastMonthExpense.value = value
@@ -34,14 +32,7 @@ const targetQuantity = ref('')
 const isStockListOpen = ref(false)
 const showErrors = ref(false)
 
-const popularStocks = [
-  { name: '케이뱅크', ticker: 'KBK', price: 6080 },
-  { name: '카카오', ticker: 'KKO', price: 47500 },
-  { name: '삼성전자', ticker: 'SMS', price: 204500 },
-  { name: 'KB금융', ticker: 'KBF', price: 155900 },
-  { name: '타이거200', ticker: 'TG2', price: 87700 },
-  { name: '현대차', ticker: 'HDY', price: 501000 },
-]
+const popularStocks = computed(() => budgetStore.stockOptions)
 
 // Get User ID from session
 const getUserId = () => {
@@ -57,15 +48,20 @@ const getUserId = () => {
   return null
 }
 
-const userId = getUserId() || 'testUser' // Hardcoded for testing
+const userId = getUserId()
 
-// 화면 로드 시 Pinia에 저장된 값이 있다면 불러오기 (localStorage 대체)
-onMounted(() => {
+onMounted(async () => {
+  try {
+    await budgetStore.initializeBudgetState(userId)
+  } catch (error) {
+    console.error('Failed to initialize budget store:', error)
+  }
+
   if (budgetStore.budget > 0) {
     lastMonthExpense.value = String(budgetStore.budget)
     targetQuantity.value = String(budgetStore.targetQuantity)
 
-    const stock = popularStocks.find((s) => s.name === budgetStore.targetStockName)
+    const stock = popularStocks.value.find((s) => s.id === budgetStore.targetStockId)
     if (stock) {
       selectedStock.value = stock
       targetStock.value = stock.name
@@ -113,54 +109,22 @@ const setTargetStock = (stock) => {
   isStockListOpen.value = false
 }
 
-// 🚀 핵심 로직: Pinia에 데이터 저장 후 홈 화면으로 이동
 const handleStartSaving = async () => {
- 
   showErrors.value = true
- 
+
   if (!lastMonthExpense.value || !selectedStock.value || !targetQuantity.value) {
     return
   }
 
-
-  /*
-  if (!userId) {
-    alert('로그인이 필요합니다.')
-    return
-  }
-  */
-
   try {
-    // 1. Save to json-server
-    const response = await fetch(`/members/${userId}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        monthlyBudget: parseInt(lastMonthExpense.value),
-        targetStockId: selectedStock.value.ticker,
-        targetQuantity: parseFloat(targetQuantity.value),
-      }),
+    await budgetStore.updateGoalSetup({
+      monthlyBudget: Number(lastMonthExpense.value),
+      targetStockId: selectedStock.value.id,
+      targetQuantity: Number(targetQuantity.value),
     })
-    // 3. 서버 저장 성공 시에만 다음 단계 진행
-    if (response.ok) {
-      // Pinia Store 업데이트
-      budgetStore.setGoalSetup(
-        Number(lastMonthExpense.value),
-        selectedStock.value.name,
-        selectedStock.value.price,
-        Number(targetQuantity.value),
-      )
 
-      alert('설정이 저장되었습니다!')
-      
-      // 4. 모든 저장이 완료된 후 메인 홈 화면으로 이동
-      router.push('/home')
-    } else {
-      alert('서버 저장 중 오류가 발생했습니다.')
-    }
-   
+    alert('설정이 저장되었습니다!')
+    router.push('/home')
   } catch (error) {
     console.error('Failed to save settings to server:', error)
     alert('서버와 통신하는 중 문제가 발생했습니다. json-server가 켜져 있는지 확인해주세요.')

--- a/src/pages/Setup/ExpenseGoalSetup.vue
+++ b/src/pages/Setup/ExpenseGoalSetup.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router' // 화면 이동을 위해 추가
+import { useBudgetStore } from '@/stores/useBudgetStore' // 방금 만든 Pinia 스토어 추가
 import {
   X,
   Wallet,
@@ -13,6 +15,9 @@ import {
   Coins,
 } from 'lucide-vue-next'
 import { Motion } from '@motionone/vue'
+// 추가
+const router = useRouter()
+const budgetStore = useBudgetStore() // 스토어 인스턴스 생성
 
 const lastMonthExpense = ref('')
 
@@ -53,25 +58,16 @@ const getUserId = () => {
 
 const userId = getUserId()
 
-// Load data on mount
+// 화면 로드 시 Pinia에 저장된 값이 있다면 불러오기 (localStorage 대체)
 onMounted(() => {
-  if (userId) {
-    const savedData = localStorage.getItem(`user_setup_${userId}`)
-    if (savedData) {
-      try {
-        const data = JSON.parse(savedData)
-        lastMonthExpense.value = data.lastMonthExpense || ''
-        targetQuantity.value = data.targetQuantity || '500'
-        if (data.selectedStockTicker) {
-          const stock = popularStocks.find((s) => s.ticker === data.selectedStockTicker)
-          if (stock) {
-            selectedStock.value = stock
-            targetStock.value = stock.name
-          }
-        }
-      } catch (e) {
-        console.error('Failed to parse saved data', e)
-      }
+  if (budgetStore.budget > 0) {
+    lastMonthExpense.value = String(budgetStore.budget)
+    targetQuantity.value = String(budgetStore.targetQuantity)
+
+    const stock = popularStocks.find((s) => s.name === budgetStore.targetStockName)
+    if (stock) {
+      selectedStock.value = stock
+      targetStock.value = stock.name
     }
   }
 })
@@ -115,7 +111,7 @@ const setTargetStock = (stock) => {
   selectedStock.value = stock
   isStockListOpen.value = false
 }
-
+// 🚀 핵심 로직: Pinia에 데이터 저장 후 홈 화면으로 이동
 const handleStartSaving = () => {
   showErrors.value = true
 
@@ -123,17 +119,16 @@ const handleStartSaving = () => {
     return
   }
 
-  if (!userId) {
-    alert('로그인이 필요합니다.')
-    return
-  }
-  const dataToSave = {
-    lastMonthExpense: lastMonthExpense.value,
-    targetQuantity: targetQuantity.value,
-    selectedStockTicker: selectedStock.value?.ticker,
-  }
-  localStorage.setItem(`user_setup_${userId}`, JSON.stringify(dataToSave))
-  alert('설정이 저장되었습니다!')
+  // Pinia Store의 Action 호출 (예산, 주식명, 주식가격, 수량)
+  budgetStore.setGoalSetup(
+    Number(lastMonthExpense.value),
+    selectedStock.value.name,
+    selectedStock.value.price,
+    Number(targetQuantity.value),
+  )
+
+  // 설정 완료 후 메인 홈 화면(/home)으로 이동
+  router.push('/home')
 }
 </script>
 

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -5,8 +5,9 @@ import { toast } from 'vue3-toastify'
 import HoneyPot from '@/components/HoneyPot.vue'
 import CalendarDetail from '@/components/CalendarDetail.vue'
 import ExpenseInput from '@/components/ExpenseInput.vue'
-import { useHoneyPot } from '@/composables/useHoneyPot'
 
+import { storeToRefs } from 'pinia'
+import { useBudgetStore } from '@/stores/useBudgetStore'
 const weekdays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 
 const calendarAccentMap = {
@@ -245,7 +246,17 @@ const historyItems = [
 const calendarTitle = computed(
   () => `${currentMonth.value.year()}년 ${currentMonth.value.month() + 1}월`,
 )
-const { displayPercentage, fillPercentage, guidelinePercentage } = useHoneyPot(800000, 555000, 360000)
+const budgetStore = useBudgetStore()
+
+// storeToRefs를 써야 반응형이 유지되어서 꿀단지가 부드럽게 움직입니다!
+const {
+  budget,
+  remainingBudget,
+  fillPercentage,
+  guidelinePercentage,
+  targetStockName,
+  targetStockPrice,
+} = storeToRefs(budgetStore)
 const visibleHistoryCount = ref(3)
 const recentItems = computed(() => historyItems.slice(0, visibleHistoryCount.value))
 const canLoadMoreHistory = computed(() => visibleHistoryCount.value < historyItems.length)
@@ -253,14 +264,23 @@ const selectedDateKey = computed(() => selectedDate.value.format('YYYY-MM-DD'))
 const selectedDayExpenses = computed(() =>
   expenseEntries.value.filter((expense) => expense.date === selectedDateKey.value),
 )
+// 4. 하드코딩된 calendarDailyReport를 스토어 데이터 기반으로 변경
 const calendarDailyReport = computed(() => {
-  const stockPrice = 47900
+  // 스토어에서 설정한 주식 가격 가져오기 (0으로 나누기 방지 위해 최소값 1)
+  const stockPrice = targetStockPrice.value || 1
+
+  // 오늘 쓴 돈 합계
   const totalSpent = selectedDayExpenses.value.reduce((sum, expense) => sum + expense.amount, 0)
+
+  // 전월 일일 평균 지출액 (30일 기준)
+  const dailyAverage = Math.floor(budget.value / 30)
+  const diffFromAverage = dailyAverage - totalSpent
 
   return {
     securedQuantity: Number((totalSpent / stockPrice).toFixed(2)),
-    stockName: '카카오',
-    savedAmount: Math.max(0, stockPrice - totalSpent),
+    stockName: targetStockName.value || '주식', // 스토어에 저장된 주식명
+    savedAmount: Math.abs(diffFromAverage), // UI에 보여줄 절댓값
+    isSaved: diffFromAverage >= 0, // 평균보다 아꼈는지 여부
     progressRate: Math.min(100, Math.round((totalSpent / stockPrice) * 100)),
   }
 })
@@ -357,17 +377,14 @@ function closeExpenseInput() {
 }
 
 function handleExpenseSave(payload) {
-  expenseEntries.value = [
-    {
-      id: Date.now(),
-      amount: payload.amount,
-      category: payload.category,
-      date: payload.date,
-      time: payload.time,
-      memo: payload.memo || '직접 입력',
-    },
-    ...expenseEntries.value,
-  ]
+  budgetStore.addExpense({
+    id: Date.now(),
+    amount: payload.amount,
+    category: payload.category,
+    date: payload.date,
+    time: payload.time,
+    memo: payload.memo || '직접 입력',
+  })
 
   toast.success('지출이 추가됐어요.', {
     autoClose: 1600,
@@ -385,7 +402,7 @@ function handleExpenseSave(payload) {
           <div class="bee-slot" aria-hidden="true">
             <div class="honey-pot-stage">
               <HoneyPot
-                :display-value="displayPercentage"
+                :display-value="Math.floor(fillPercentage)"
                 :fill-percentage="fillPercentage"
                 :guideline-percentage="guidelinePercentage"
               />
@@ -394,17 +411,22 @@ function handleExpenseSave(payload) {
 
           <div class="balance-copy">
             <p class="balance-label">이번 달 생활비 남음</p>
-            <p class="balance-amount">₩245,000</p>
+            <p class="balance-amount">₩{{ remainingBudget.toLocaleString() }}</p>
             <p class="balance-hint">빨간 선은 목표 주식 가격</p>
             <p class="balance-hint">꿀단지는 현재 남은 생활비를 비율을 보여줘요</p>
           </div>
         </section>
 
         <section class="stock-card">
-          <div class="stock-badge">QQQ</div>
+          <div class="stock-badge">
+            {{ targetStockName ? targetStockName.substring(0, 2) : '주식' }}
+          </div>
           <div class="stock-copy">
-            <p class="stock-label">오늘 아끼면 살 수 있는 주식</p>
-            <p class="stock-value">QQQ 0.5주</p>
+            <p class="stock-label">남은 생활비로 살 수 있는 주식</p>
+            <p class="stock-value">
+              {{ targetStockName }}
+              {{ targetStockPrice ? (remainingBudget / targetStockPrice).toFixed(1) : 0 }}주
+            </p>
           </div>
           <button
             class="stock-arrow-button"

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import dayjs from 'dayjs'
 import { toast } from 'vue3-toastify'
 import HoneyPot from '@/components/HoneyPot.vue'
@@ -32,53 +32,11 @@ const calendarAccentMap = {
   '2024-05-30': 'warm',
 }
 
-const currentMonth = ref(dayjs('2024-05-01'))
-const selectedDate = ref(dayjs('2024-05-03'))
+const currentMonth = ref(dayjs().startOf('month'))
+const selectedDate = ref(dayjs())
 const isCalendarDetailOpen = ref(false)
 const isExpenseInputOpen = ref(false)
 const reopenCalendarDetail = ref(false)
-const expenseEntries = ref([
-  {
-    id: 1,
-    category: '카페/음료',
-    amount: 4800,
-    date: '2024-05-02',
-    time: '08:40',
-    memo: '출근 전 아메리카노',
-  },
-  {
-    id: 2,
-    category: '일반식사',
-    amount: 11000,
-    date: '2024-05-02',
-    time: '12:15',
-    memo: '점심 식사',
-  },
-  {
-    id: 3,
-    category: '카페/음료',
-    amount: 5400,
-    date: '2024-05-03',
-    time: '09:10',
-    memo: '아이스 라떼',
-  },
-  {
-    id: 4,
-    category: '일반식사',
-    amount: 10200,
-    date: '2024-05-03',
-    time: '12:20',
-    memo: '회사 앞 점심',
-  },
-  {
-    id: 5,
-    category: '쇼핑',
-    amount: 10000,
-    date: '2024-05-03',
-    time: '19:40',
-    memo: '생활용품 구매',
-  },
-])
 
 const historyItems = [
   {
@@ -250,40 +208,43 @@ const budgetStore = useBudgetStore()
 
 // storeToRefs를 써야 반응형이 유지되어서 꿀단지가 부드럽게 움직입니다!
 const {
-  budget,
+  expenses,
   remainingBudget,
   fillPercentage,
   guidelinePercentage,
   targetStockName,
   targetStockPrice,
 } = storeToRefs(budgetStore)
+
+const getSessionMemberId = () => {
+  try {
+    return JSON.parse(localStorage.getItem('userSession') || 'null')?.id ?? null
+  } catch {
+    return null
+  }
+}
+
+onMounted(async () => {
+  try {
+    await budgetStore.initializeBudgetState(getSessionMemberId())
+    const latestExpenseDate = budgetStore.recentExpenses[0]?.date
+
+    if (latestExpenseDate) {
+      selectedDate.value = dayjs(latestExpenseDate)
+      currentMonth.value = selectedDate.value.startOf('month')
+    }
+  } catch (error) {
+    console.error('Failed to initialize budget store:', error)
+  }
+})
+
 const visibleHistoryCount = ref(3)
 const recentItems = computed(() => historyItems.slice(0, visibleHistoryCount.value))
 const canLoadMoreHistory = computed(() => visibleHistoryCount.value < historyItems.length)
 const selectedDateKey = computed(() => selectedDate.value.format('YYYY-MM-DD'))
-const selectedDayExpenses = computed(() =>
-  expenseEntries.value.filter((expense) => expense.date === selectedDateKey.value),
-)
-// 4. 하드코딩된 calendarDailyReport를 스토어 데이터 기반으로 변경
-const calendarDailyReport = computed(() => {
-  // 스토어에서 설정한 주식 가격 가져오기 (0으로 나누기 방지 위해 최소값 1)
-  const stockPrice = targetStockPrice.value || 1
-
-  // 오늘 쓴 돈 합계
-  const totalSpent = selectedDayExpenses.value.reduce((sum, expense) => sum + expense.amount, 0)
-
-  // 전월 일일 평균 지출액 (30일 기준)
-  const dailyAverage = Math.floor(budget.value / 30)
-  const diffFromAverage = dailyAverage - totalSpent
-
-  return {
-    securedQuantity: Number((totalSpent / stockPrice).toFixed(2)),
-    stockName: targetStockName.value || '주식', // 스토어에 저장된 주식명
-    savedAmount: Math.abs(diffFromAverage), // UI에 보여줄 절댓값
-    isSaved: diffFromAverage >= 0, // 평균보다 아꼈는지 여부
-    progressRate: Math.min(100, Math.round((totalSpent / stockPrice) * 100)),
-  }
-})
+const expenseDateSet = computed(() => new Set(expenses.value.map((expense) => expense.date)))
+const selectedDayExpenses = computed(() => budgetStore.getExpensesByDate(selectedDateKey.value))
+const calendarDailyReport = computed(() => budgetStore.getDailyReport(selectedDateKey.value))
 
 const calendarDays = computed(() => {
   const monthStart = currentMonth.value.startOf('month')
@@ -304,7 +265,7 @@ const calendarDays = computed(() => {
       key: isoDate,
       label: date.date(),
       isoDate,
-      dotTone: calendarAccentMap[isoDate] ?? null,
+      dotTone: expenseDateSet.value.has(isoDate) ? (calendarAccentMap[isoDate] ?? 'warm') : null,
       inCurrentMonth,
       isSelected: date.isSame(selectedDate.value, 'day'),
       isToday: date.isSame(dayjs(), 'day'),
@@ -329,12 +290,6 @@ function selectDate(isoDate) {
   if (!nextDate.isSame(currentMonth.value, 'month')) {
     currentMonth.value = nextDate.startOf('month')
   }
-}
-
-function handleAddClick() {
-  toast.info('추가 기능은 다음 단계에서 연결될 예정이에요.', {
-    autoClose: 1800,
-  })
 }
 
 function handleStockClick() {
@@ -376,19 +331,19 @@ function closeExpenseInput() {
   }
 }
 
-function handleExpenseSave(payload) {
-  budgetStore.addExpense({
-    id: Date.now(),
-    amount: payload.amount,
-    category: payload.category,
-    date: payload.date,
-    time: payload.time,
-    memo: payload.memo || '직접 입력',
-  })
+async function handleExpenseSave(payload) {
+  try {
+    await budgetStore.addExpense(payload)
 
-  toast.success('지출이 추가됐어요.', {
-    autoClose: 1600,
-  })
+    toast.success('지출이 추가됐어요.', {
+      autoClose: 1600,
+    })
+  } catch (error) {
+    console.error('Failed to save expense:', error)
+    toast.error('지출 저장에 실패했어요. json-server 상태를 확인해주세요.', {
+      autoClose: 2200,
+    })
+  }
 }
 </script>
 

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -1,66 +1,288 @@
 import { defineStore } from 'pinia'
 
+const API_BASE = '/api'
+
+async function requestJson(path, options) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+    ...options,
+  })
+
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+function toNumber(value, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function toDateKey(spentAt) {
+  return typeof spentAt === 'string' ? spentAt.slice(0, 10) : ''
+}
+
+function toTimeKey(spentAt) {
+  return typeof spentAt === 'string' && spentAt.includes('T') ? spentAt.slice(11, 16) : ''
+}
+
 export const useBudgetStore = defineStore('budget', {
-  // 1. State: 전역으로 관리할 데이터 원본
   state: () => ({
-    budget: 0, // 총 예산 (지난달 생활비)
-    targetStockName: '', // 목표 주식명
-    targetStockPrice: 0, // 목표 주식 1주 가격
-    targetQuantity: 0, // 목표 수량
-    expenses: [], // 지출 내역 배열
+    memberId: null,
+    budget: 0,
+    targetStockId: null,
+    targetQuantity: 0,
+    stocks: [],
+    prices: [],
+    categories: [],
+    expenses: [],
+    isLoading: false,
+    error: null,
+    initialized: false,
   }),
 
-  // 2. Getters: State를 기반으로 자동 계산되는 값들 (반응형)
   getters: {
-    // 총 지출액
-    totalExpense: (state) => {
-      return state.expenses.reduce((sum, exp) => sum + exp.amount, 0)
+    categoryById: (state) => new Map(state.categories.map((category) => [category.id, category])),
+
+    latestPriceByStockId: (state) => {
+      return state.prices.reduce((map, price) => {
+        const previous = map.get(price.stockId)
+        if (!previous || new Date(price.recordedAt) > new Date(previous.recordedAt)) {
+          map.set(price.stockId, price)
+        }
+        return map
+      }, new Map())
     },
 
-    // 목표 주식 총액 (가이드라인 선의 기준이 될 금액)
-    targetTotalAmount: (state) => {
-      return state.targetStockPrice * state.targetQuantity
+    targetStock(state) {
+      return state.stocks.find((stock) => stock.id === state.targetStockId) ?? null
     },
 
-    // 남은 예산
+    targetStockName() {
+      return this.targetStock?.name ?? ''
+    },
+
+    targetStockPrice() {
+      return this.latestPriceByStockId.get(this.targetStockId)?.price ?? 0
+    },
+
+    stockOptions(state) {
+      return state.stocks.map((stock) => ({
+        ...stock,
+        ticker: stock.ticker ?? stock.symbol ?? String(stock.id),
+        price: this.latestPriceByStockId.get(stock.id)?.price ?? 0,
+      }))
+    },
+
+    totalExpense: (state) => state.expenses.reduce((sum, expense) => sum + expense.amount, 0),
+
+    monthlyExpenseTotal() {
+      return this.totalExpense
+    },
+
+    expensesByDate(state) {
+      return state.expenses.reduce((groups, expense) => {
+        if (!groups[expense.date]) {
+          groups[expense.date] = []
+        }
+        groups[expense.date].push(expense)
+        return groups
+      }, {})
+    },
+
+    getExpensesByDate() {
+      return (date) => this.expensesByDate[date] ?? []
+    },
+
     remainingBudget(state) {
       return state.budget - this.totalExpense
     },
 
-    // 꿀통 채워진 비율 (0 ~ 100%)
     fillPercentage(state) {
       if (state.budget <= 0) return 0
       const ratio = (this.remainingBudget / state.budget) * 100
       return Math.min(Math.max(ratio, 0), 100)
     },
 
-    // 가이드라인 비율 (0 ~ 100%)
     guidelinePercentage(state) {
-      if (state.budget <= 0) return 0
-      return (this.targetTotalAmount / state.budget) * 100
+      if (state.budget <= 0 || this.targetStockPrice <= 0) return 0
+      const ratio = (this.targetStockPrice / state.budget) * 100
+      return Math.min(Math.max(ratio, 0), 100)
     },
 
-    // 전월 일일 평균 지출액 (한 달 30일 기준)
     dailyAverage: (state) => {
       if (state.budget <= 0) return 0
       return Math.floor(state.budget / 30)
     },
-  },
 
-  // 3. Actions: State를 변경하는 함수들
-  actions: {
-    // Setup 화면에서 호출하여 목표 설정
-    setGoalSetup(budget, stockName, stockPrice, quantity) {
-      this.budget = budget
-      this.targetStockName = stockName
-      this.targetStockPrice = stockPrice
-      this.targetQuantity = quantity
+    targetTotalAmount(state) {
+      return this.targetStockPrice * state.targetQuantity
     },
 
-    // 캘린더나 Home 화면에서 지출 추가
-    addExpense(expense) {
-      // unshift를 쓰면 최신 지출 내역이 배열의 맨 앞(위쪽)에 추가됩니다.
-      this.expenses.unshift(expense)
+    securedQuantity() {
+      if (this.targetStockPrice <= 0) return 0
+      return Number((Math.max(this.remainingBudget, 0) / this.targetStockPrice).toFixed(2))
+    },
+
+    progressRate(state) {
+      if (state.targetQuantity <= 0) return 0
+      return Math.min(100, Math.round((this.securedQuantity / state.targetQuantity) * 100))
+    },
+
+    recentExpenses(state) {
+      return [...state.expenses].sort((a, b) => new Date(b.spentAt) - new Date(a.spentAt))
+    },
+
+    getDailyReport() {
+      return (date) => {
+        const dayExpenses = this.getExpensesByDate(date)
+        const totalSpent = dayExpenses.reduce((sum, expense) => sum + expense.amount, 0)
+        const stockPrice = this.targetStockPrice || 1
+        const diffFromAverage = this.dailyAverage - totalSpent
+
+        return {
+          securedQuantity: Number((totalSpent / stockPrice).toFixed(2)),
+          stockName: this.targetStockName || '주식',
+          savedAmount: Math.abs(diffFromAverage),
+          isSaved: diffFromAverage >= 0,
+          progressRate: Math.min(100, Math.round((totalSpent / stockPrice) * 100)),
+        }
+      }
+    },
+  },
+
+  actions: {
+    normalizeExpense(expense) {
+      const category = this.categoryById.get(expense.categoryId)
+
+      return {
+        ...expense,
+        amount: toNumber(expense.amount),
+        category: expense.category ?? category?.name ?? '기타',
+        date: expense.date ?? toDateKey(expense.spentAt),
+        time: expense.time ?? toTimeKey(expense.spentAt),
+        memo: expense.memo ?? '',
+      }
+    },
+
+    applyMember(member) {
+      this.memberId = member?.id ?? null
+      this.budget = toNumber(member?.monthlyBudget)
+      this.targetStockId = member?.targetStockId ?? null
+      this.targetQuantity = toNumber(member?.targetQuantity)
+    },
+
+    resolveMember(members, requestedMemberId) {
+      if (requestedMemberId !== null && requestedMemberId !== undefined) {
+        const matched = members.find((member) => String(member.id) === String(requestedMemberId))
+        if (matched) return matched
+      }
+
+      return (
+        members.find((member) => toNumber(member.monthlyBudget) > 0 && member.targetStockId) ??
+        members[0] ??
+        null
+      )
+    },
+
+    async loadReferenceData() {
+      const [stocks, prices, categories] = await Promise.all([
+        requestJson('/stocks'),
+        requestJson('/prices'),
+        requestJson('/categories'),
+      ])
+
+      this.stocks = stocks
+      this.prices = prices
+      this.categories = categories
+    },
+
+    async loadExpenses(memberId = this.memberId) {
+      const expenses = await requestJson('/expenses')
+      this.expenses = expenses
+        .filter((expense) => String(expense.memberId) === String(memberId))
+        .map((expense) => this.normalizeExpense(expense))
+        .sort((a, b) => new Date(b.spentAt) - new Date(a.spentAt))
+    },
+
+    async initializeBudgetState(memberId = null) {
+      if (this.isLoading) return
+
+      this.isLoading = true
+      this.error = null
+
+      try {
+        const members = await requestJson('/members')
+        await this.loadReferenceData()
+
+        const member = this.resolveMember(members, memberId)
+        if (!member) {
+          this.initialized = true
+          return
+        }
+
+        this.applyMember(member)
+        await this.loadExpenses(member.id)
+        this.initialized = true
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error)
+        throw error
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    async updateGoalSetup({ monthlyBudget, targetStockId, targetQuantity }) {
+      if (!this.memberId) {
+        await this.initializeBudgetState()
+      }
+
+      const payload = {
+        monthlyBudget: toNumber(monthlyBudget),
+        targetStockId,
+        targetQuantity: toNumber(targetQuantity),
+      }
+
+      const member = await requestJson(`/members/${this.memberId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      })
+
+      this.applyMember(member)
+      return member
+    },
+
+    async addExpense(payload) {
+      if (!this.memberId) {
+        await this.initializeBudgetState()
+      }
+
+      const category =
+        this.categories.find((item) => item.id === payload.categoryId) ??
+        this.categories.find((item) => item.name === payload.category)
+
+      const spentAt =
+        payload.spentAt ?? `${payload.date}T${payload.time || new Date().toTimeString().slice(0, 5)}:00`
+
+      const expense = await requestJson('/expenses', {
+        method: 'POST',
+        body: JSON.stringify({
+          memberId: this.memberId,
+          categoryId: category?.id ?? payload.categoryId ?? null,
+          amount: toNumber(payload.amount),
+          memo: payload.memo || '직접 입력',
+          spentAt,
+        }),
+      })
+
+      const normalizedExpense = this.normalizeExpense(expense)
+      this.expenses.unshift(normalizedExpense)
+      return normalizedExpense
     },
   },
 })

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -1,0 +1,66 @@
+import { defineStore } from 'pinia'
+
+export const useBudgetStore = defineStore('budget', {
+  // 1. State: 전역으로 관리할 데이터 원본
+  state: () => ({
+    budget: 0, // 총 예산 (지난달 생활비)
+    targetStockName: '', // 목표 주식명
+    targetStockPrice: 0, // 목표 주식 1주 가격
+    targetQuantity: 0, // 목표 수량
+    expenses: [], // 지출 내역 배열
+  }),
+
+  // 2. Getters: State를 기반으로 자동 계산되는 값들 (반응형)
+  getters: {
+    // 총 지출액
+    totalExpense: (state) => {
+      return state.expenses.reduce((sum, exp) => sum + exp.amount, 0)
+    },
+
+    // 목표 주식 총액 (가이드라인 선의 기준이 될 금액)
+    targetTotalAmount: (state) => {
+      return state.targetStockPrice * state.targetQuantity
+    },
+
+    // 남은 예산
+    remainingBudget(state) {
+      return state.budget - this.totalExpense
+    },
+
+    // 꿀통 채워진 비율 (0 ~ 100%)
+    fillPercentage(state) {
+      if (state.budget <= 0) return 0
+      const ratio = (this.remainingBudget / state.budget) * 100
+      return Math.min(Math.max(ratio, 0), 100)
+    },
+
+    // 가이드라인 비율 (0 ~ 100%)
+    guidelinePercentage(state) {
+      if (state.budget <= 0) return 0
+      return (this.targetTotalAmount / state.budget) * 100
+    },
+
+    // 전월 일일 평균 지출액 (한 달 30일 기준)
+    dailyAverage: (state) => {
+      if (state.budget <= 0) return 0
+      return Math.floor(state.budget / 30)
+    },
+  },
+
+  // 3. Actions: State를 변경하는 함수들
+  actions: {
+    // Setup 화면에서 호출하여 목표 설정
+    setGoalSetup(budget, stockName, stockPrice, quantity) {
+      this.budget = budget
+      this.targetStockName = stockName
+      this.targetStockPrice = stockPrice
+      this.targetQuantity = quantity
+    },
+
+    // 캘린더나 Home 화면에서 지출 추가
+    addExpense(expense) {
+      // unshift를 쓰면 최신 지출 내역이 배열의 맨 앞(위쪽)에 추가됩니다.
+      this.expenses.unshift(expense)
+    },
+  },
+})


### PR DESCRIPTION
## 🚀 PR 개요
- 작업 내용 요약: 예산, 목표 주식, 지출 데이터를 Pinia store에서 공통 관리하도록 정리하고 Home/Setup 페이지의 기존 흐름이 깨지지 않도록 복구했습니다.
- 관련 이슈: #55

---

## ✨ 변경 사항
- `useBudgetStore`에 회원, 주식, 가격, 카테고리, 지출 데이터를 로드하는 초기화 action을 추가했습니다.
- 예산 잔액, 꿀단지 비율, 목표 주식 가격, 날짜별 지출, 일일 리포트 계산을 store getter로 분리했습니다.
- `ExpenseGoalSetup`이 store를 통해 기존 설정값을 복원하고 목표 예산/주식 설정을 저장하도록 수정했습니다.
- `HomePage`의 지출 source of truth를 Pinia store로 통일하고, 캘린더 상세/일일 리포트도 store getter를 사용하도록 정리했습니다.
- `ExpenseInput`에서 사용하지 않는 store 의존성을 제거해 입력 컴포넌트 역할을 유지했습니다.

---

## 🧩 작업 유형
- [x] 🐛 Bug Fix
- [x] ✨ Feature
- [x] 🔧 Refactor
- [ ] 🎨 UI/UX
- [x] 🔌 API
- [ ] ⚡ Performance
- [ ] ⚙️ Config / Build

---

## 📍 주요 변경 파일
- `src/stores/useBudgetStore.js`
- `src/pages/Setup/ExpenseGoalSetup.vue`
- `src/pages/homePage/HomePage.vue`
- `src/components/ExpenseInput.vue`

---

## 🖼️ 스크린샷 (선택)
> UI 변경 없음

---

## 🧪 테스트 방법
1. `npm run build` 실행 후 빌드 성공 확인
2. `npm run dev` 실행 후 Vite 개발 서버와 json-server 동시 실행 확인
3. `http://localhost:3000/members` 응답 확인

---

## ⚠️ 체크리스트
- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 기존 기능 영향 없음
- [ ] 반응형/UI 확인 (필요 시)

---

## 💬 기타 사항
- 이번 PR 범위는 Pinia store 기반 구축과 Home/Setup 최소 연동 복구까지로 제한했습니다.
- ReportPage 전환, auth/session store 분리, 전체 페이지 API 레이어 통합은 후속 이슈로 분리하는 것을 추천합니다.
- `npx eslint .`는 기존 Vue SFC TypeScript 파싱 설정 문제로 실패합니다. `npm run build`는 통과했습니다.
