### PR TITLE
feat: 주식 티커 기반 홈 주식 뱃지 표시 및 db.json 스키마 보강

### DIFF
--- a/db.json
+++ b/db.json
@@ -73,23 +73,33 @@
   "stocks": [
     {
       "id": 1,
-      "name": "카카오"
+      "name": "카카오",
+      "ticker": "KAK",
+      "realTicker": "035720"
     },
     {
       "id": 2,
-      "name": "삼성전자"
+      "name": "삼성전자",
+      "ticker": "SAM",
+      "realTicker": "005930"
     },
     {
       "id": 3,
-      "name": "케이뱅크"
+      "name": "케이뱅크",
+      "ticker": "KBN",
+      "realTicker": null
     },
     {
       "id": 4,
-      "name": "KB금융"
+      "name": "KB금융",
+      "ticker": "KBF",
+      "realTicker": "105560"
     },
     {
       "id": 5,
-      "name": "TIGER200"
+      "name": "TIGER200",
+      "ticker": "TIG",
+      "realTicker": "102110"
     }
   ],
   "prices": [

--- a/scripts/validate-db.mjs
+++ b/scripts/validate-db.mjs
@@ -63,6 +63,8 @@ uniqueById(reports, 'reports');
 const memberIds = new Set(members.map((member) => member.id));
 const categoryIds = new Set(categories.map((category) => category.id));
 const stockIds = new Set(stocks.map((stock) => stock.id));
+const stockTickers = new Set();
+const realTickerPattern = /^\d{6}$/;
 
 const memberIdTypes = [...new Set(members.map((member) => typeof member.id))];
 assert(
@@ -83,6 +85,20 @@ for (const expense of expenses) {
 for (const price of prices) {
   assert(stockIds.has(price.stockId), `price ${price.id} points to missing stock ${price.stockId}`);
   assert(typeof price.price === 'number', `price ${price.id} price must be a number`);
+}
+
+for (const stock of stocks) {
+  assert(typeof stock.name === 'string' && stock.name.length > 0, `stock ${stock.id} name must be a non-empty string`);
+  assert(
+    typeof stock.ticker === 'string' && stock.ticker.length > 0,
+    `stock ${stock.id} ticker must be a non-empty string`,
+  );
+  assert(!stockTickers.has(stock.ticker), `stocks has duplicate ticker: ${stock.ticker}`);
+  stockTickers.add(stock.ticker);
+  assert(
+    stock.realTicker === null || (typeof stock.realTicker === 'string' && realTickerPattern.test(stock.realTicker)),
+    `stock ${stock.id} realTicker must be null or a 6-digit string`,
+  );
 }
 
 for (const report of reports) {

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -213,6 +213,7 @@ const {
   fillPercentage,
   guidelinePercentage,
   targetStockName,
+  targetStockTicker,
   targetStockPrice,
 } = storeToRefs(budgetStore)
 
@@ -382,7 +383,7 @@ async function handleExpenseSave(payload) {
 
         <section class="stock-card">
           <div class="stock-badge">
-            {{ targetStockName ? targetStockName.substring(0, 3) : '주식' }}
+            {{ targetStockTicker || '주식' }}
           </div>
           <div class="stock-copy">
             <p class="stock-label">오늘 쓴 돈으로 살 수 있었던 주식</p>

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -67,6 +67,14 @@ export const useBudgetStore = defineStore('budget', {
       return this.targetStock?.name ?? ''
     },
 
+    targetStockTicker() {
+      return this.targetStock?.ticker ?? this.targetStock?.symbol ?? ''
+    },
+
+    targetStockRealTicker() {
+      return this.targetStock?.realTicker ?? null
+    },
+
     targetStockPrice() {
       return this.latestPriceByStockId.get(this.targetStockId)?.price ?? 0
     },
@@ -75,6 +83,7 @@ export const useBudgetStore = defineStore('budget', {
       return state.stocks.map((stock) => ({
         ...stock,
         ticker: stock.ticker ?? stock.symbol ?? String(stock.id),
+        realTicker: stock.realTicker ?? null,
         price: this.latestPriceByStockId.get(stock.id)?.price ?? 0,
       }))
     },


### PR DESCRIPTION
## 🚀 PR 개요
- 작업 내용 요약: 홈 화면 주식 카드의 뱃지를 주식명 substring 방식에서 DB의 `ticker` 기반 표시로 변경하고, `db.json` 주식 스키마를 보강했습니다.
- 관련 이슈: #70

---

## ✨ 변경 사항
- `db.json`의 `stocks` 데이터에 `ticker`, `realTicker` 필드를 추가했습니다.
- Pinia 예산 스토어에 현재 목표 주식의 `targetStockTicker`, `targetStockRealTicker` getter를 추가했습니다.
- 홈 화면 주식 카드 뱃지가 `targetStockName.substring(...)` 대신 `targetStockTicker`를 표시하도록 수정했습니다.
- `stockOptions`에서 `realTicker`를 함께 내려주도록 정리했습니다.
- DB 검증 스크립트에 `ticker` 필수 여부와 `realTicker` 형식 검증을 추가했습니다.

---

## 🧩 작업 유형
- [ ] 🐛 Bug Fix
- [x] ✨ Feature
- [ ] 🔧 Refactor
- [x] 🎨 UI/UX
- [ ] 🔌 API
- [ ] ⚡ Performance
- [ ] ⚙️ Config / Build

---

## 📍 주요 변경 파일
- `db.json`
- `scripts/validate-db.mjs`
- `src/stores/useBudgetStore.js`
- `src/pages/homePage/HomePage.vue`

---

## 🖼️ 스크린샷 (선택)
> 홈 화면 주식 카드 뱃지에 `KAK`, `SAM`, `KBN`, `KBF`, `TIG` 형태의 ticker 표시 확인 필요
<img width="636" height="227" alt="image" src="https://github.com/user-attachments/assets/964968c5-654a-4c9d-90db-8918a3aa0bec" />

---

## 🧪 테스트 방법
1. `npm run validate:db`
2. `npm run build`
3. 홈 화면에서 목표 주식 뱃지가 주식명 일부가 아닌 `ticker` 값으로 표시되는지 확인

---

## ⚠️ 체크리스트
- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 기존 기능 영향 없음
- [x] 반응형/UI 확인 (필요 시)

---

## 💬 기타 사항
- `realTicker`는 실제 종목 코드 보존을 위해 문자열로 관리합니다.
- 케이뱅크처럼 실제 종목 코드가 없는 경우 `realTicker: null`을 허용합니다.
- `npm run build` 시 기존 chunk size warning은 표시되지만 빌드는 성공했습니다.
