### PR TITLE
fix: 홈 화면 데이터 연동 및 꿀통 목표 기준선 계산 오류 수정

### DIFF
--- a/db.json
+++ b/db.json
@@ -438,6 +438,14 @@
       "amount": 1250,
       "memo": "지하철",
       "spentAt": "2026-04-08T08:15:00"
+    },
+    {
+      "memberId": 2,
+      "categoryId": 1,
+      "amount": 5000,
+      "memo": "피자",
+      "spentAt": "2026-04-04T14:58:00",
+      "id": 39
     }
   ],
   "reports": [

--- a/src/components/CalendarDetail.vue
+++ b/src/components/CalendarDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Plus } from 'lucide-vue-next'
+import { Cloud, CloudRain, Plus, Sun } from 'lucide-vue-next'
 
 interface Expense {
   id: number
@@ -116,12 +116,11 @@ const getCategoryIcon = (category: string) => {
               class="bg-surface-container-low border border-outline-variant p-6 rounded-[2.5rem] relative overflow-hidden"
             >
               <div
-                class="daily-weather absolute -right-1 bottom-1 w-36 h-36 pointer-events-none"
+                class="daily-weather absolute right-4 bottom-4 w-24 h-24 pointer-events-none"
                 :class="weatherClass"
                 role="img"
                 :aria-label="weatherLabel"
               >
-                <span class="daily-weather__sun" aria-hidden="true"></span>
                 <div
                   class="honey-pot-mask daily-weather__cloud relative w-full h-full bg-outline-variant overflow-hidden"
                 >
@@ -134,9 +133,15 @@ const getCategoryIcon = (category: string) => {
                     ></div>
                   </div>
                 </div>
-                <span class="daily-weather__drop daily-weather__drop--1" aria-hidden="true"></span>
-                <span class="daily-weather__drop daily-weather__drop--2" aria-hidden="true"></span>
-                <span class="daily-weather__drop daily-weather__drop--3" aria-hidden="true"></span>
+                <span
+                  class="daily-weather__badge"
+                  :class="`daily-weather__badge--${weatherType}`"
+                  aria-hidden="true"
+                >
+                  <Sun v-if="weatherType === 'sunny'" :size="34" :stroke-width="2.4" />
+                  <CloudRain v-else-if="weatherType === 'rainy'" :size="34" :stroke-width="2.4" />
+                  <Cloud v-else :size="34" :stroke-width="2.4" />
+                </span>
               </div>
 
               <div class="relative z-10">
@@ -238,50 +243,53 @@ const getCategoryIcon = (category: string) => {
 }
 
 .daily-weather {
-  opacity: 0.2;
+  opacity: 0.46;
   isolation: isolate;
   transition:
     opacity 180ms ease,
     transform 180ms ease;
 }
 
-.daily-weather__sun {
-  position: absolute;
-  top: 1.95rem;
-  right: 4.3rem;
-  width: 2.85rem;
-  height: 2.85rem;
-  border-radius: 9999px;
-  background: linear-gradient(145deg, #fff3a8 0%, #ffbc50 78%);
-  box-shadow:
-    0 0 0 0.42rem rgba(255, 188, 80, 0.16),
-    0 0.8rem 1.7rem rgba(255, 174, 54, 0.35);
-  opacity: 0;
-  transform: scale(0.78);
-  z-index: 1;
-  transition:
-    opacity 180ms ease,
-    transform 180ms ease;
-}
-
-.daily-weather__sun::before {
-  content: '';
-  position: absolute;
-  inset: -0.52rem;
-  border-radius: inherit;
-  border: 0.22rem solid rgba(255, 188, 80, 0.24);
-  box-shadow: 0 0 1.2rem rgba(255, 188, 80, 0.18);
-  opacity: 1;
-  z-index: -1;
-}
-
 .daily-weather__cloud {
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 1;
   transition:
     background-color 180ms ease,
     transform 180ms ease;
+}
+
+.daily-weather__badge {
+  position: absolute;
+  top: 0.1rem;
+  right: 0.1rem;
+  display: grid;
+  place-items: center;
+  width: 2.65rem;
+  height: 2.65rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow:
+    0 0.55rem 1rem rgba(72, 56, 38, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  z-index: 3;
+  transition:
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.daily-weather__badge--sunny {
+  color: #d98a12;
+  background: rgba(255, 244, 201, 0.92);
+}
+
+.daily-weather__badge--rainy {
+  color: #4f79aa;
+  background: rgba(229, 239, 249, 0.92);
+}
+
+.daily-weather__badge--neutral {
+  color: #7a838d;
 }
 
 .daily-weather__fill,
@@ -289,60 +297,26 @@ const getCategoryIcon = (category: string) => {
   transition: background-color 180ms ease;
 }
 
-.daily-weather__drop {
-  position: absolute;
-  bottom: 1rem;
-  width: 0.68rem;
-  height: 1.05rem;
-  border-radius: 9999px 9999px 9999px 0.18rem;
-  background: linear-gradient(145deg, #a7cff6 0%, #5f91c9 78%);
-  box-shadow:
-    0 0 0 0.24rem rgba(95, 145, 201, 0.12),
-    0 0.55rem 1rem rgba(95, 145, 201, 0.24);
-  opacity: 0;
-  transform: rotate(38deg) translateY(-0.2rem);
-  z-index: 3;
-  transition: opacity 180ms ease;
-}
-
-.daily-weather__drop--1 {
-  right: 2.65rem;
-}
-
-.daily-weather__drop--2 {
-  right: 4.05rem;
-  bottom: 0.55rem;
-  width: 0.72rem;
-  height: 1.16rem;
-}
-
-.daily-weather__drop--3 {
-  right: 5.55rem;
-}
-
 .daily-weather--sunny {
-  opacity: 0.64;
-  transform: translate(-0.45rem, -0.35rem);
-}
-
-.daily-weather--sunny .daily-weather__sun {
-  opacity: 1;
-  transform: scale(1);
+  opacity: 0.72;
 }
 
 .daily-weather--sunny .daily-weather__cloud {
   background-color: #ffe0a0;
-  transform: translate(0.72rem, 1.35rem) scale(0.82);
+  transform: translate(0.25rem, 0.55rem) scale(0.82);
+}
+
+.daily-weather--sunny .daily-weather__badge {
+  transform: translate(-0.15rem, -0.1rem);
 }
 
 .daily-weather--rainy {
-  opacity: 0.58;
-  transform: translate(-0.3rem, -0.2rem);
+  opacity: 0.68;
 }
 
 .daily-weather--rainy .daily-weather__cloud {
   background-color: #8794a1;
-  transform: translate(0.35rem, 0.25rem) scale(0.9);
+  transform: translate(0.1rem, 0.25rem) scale(0.86);
 }
 
 .daily-weather--rainy .daily-weather__fill,
@@ -350,28 +324,8 @@ const getCategoryIcon = (category: string) => {
   background-color: #5f7286;
 }
 
-.daily-weather--rainy .daily-weather__drop {
-  opacity: 1;
-  animation: weather-rain-fall 1.15s ease-in-out infinite;
-}
-
-.daily-weather--rainy .daily-weather__drop--2 {
-  animation-delay: 0.18s;
-}
-
-.daily-weather--rainy .daily-weather__drop--3 {
-  animation-delay: 0.34s;
-}
-
-@keyframes weather-rain-fall {
-  0%,
-  100% {
-    transform: rotate(38deg) translateY(-0.25rem);
-  }
-
-  50% {
-    transform: rotate(38deg) translateY(0.36rem);
-  }
+.daily-weather--neutral .daily-weather__cloud {
+  transform: scale(0.88);
 }
 
 /* 아이콘 통일 핵심 */

--- a/src/components/CalendarDetail.vue
+++ b/src/components/CalendarDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Cloud, CloudRain, Plus, Sun } from 'lucide-vue-next'
+import { Plus } from 'lucide-vue-next'
 
 interface Expense {
   id: number
@@ -121,6 +121,7 @@ const getCategoryIcon = (category: string) => {
                 role="img"
                 :aria-label="weatherLabel"
               >
+                <span class="daily-weather__sun" aria-hidden="true"></span>
                 <div
                   class="honey-pot-mask daily-weather__cloud relative w-full h-full bg-outline-variant overflow-hidden"
                 >
@@ -133,15 +134,9 @@ const getCategoryIcon = (category: string) => {
                     ></div>
                   </div>
                 </div>
-                <span
-                  class="daily-weather__badge"
-                  :class="`daily-weather__badge--${weatherType}`"
-                  aria-hidden="true"
-                >
-                  <Sun v-if="weatherType === 'sunny'" :size="34" :stroke-width="2.4" />
-                  <CloudRain v-else-if="weatherType === 'rainy'" :size="34" :stroke-width="2.4" />
-                  <Cloud v-else :size="34" :stroke-width="2.4" />
-                </span>
+                <span class="daily-weather__drop daily-weather__drop--1" aria-hidden="true"></span>
+                <span class="daily-weather__drop daily-weather__drop--2" aria-hidden="true"></span>
+                <span class="daily-weather__drop daily-weather__drop--3" aria-hidden="true"></span>
               </div>
 
               <div class="relative z-10">
@@ -165,7 +160,9 @@ const getCategoryIcon = (category: string) => {
           </div>
 
           <!-- 총 지출 -->
-          <div class="bg-surface p-5 rounded-2xl mb-10">
+          <div
+            class="bg-surface border border-outline-variant/80 p-5 rounded-2xl mb-10 shadow-[0_10px_28px_rgba(45,41,38,0.06)]"
+          >
             <div class="flex items-center gap-4">
               <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
                 <!-- 🔥 수정된 부분 -->
@@ -174,25 +171,31 @@ const getCategoryIcon = (category: string) => {
                 </span>
               </div>
 
-              <div class="flex-1">
-                <p class="text-xs font-bold mb-1">오늘의 총 지출</p>
-                <p class="text-2xl font-extrabold">{{ totalAmount.toLocaleString() }}원</p>
-
-                <p v-if="dailyReport.isSaved" class="text-xs mt-2">
-                  평균보다
-                  <span class="font-bold text-secondary">
-                    {{ dailyReport.savedAmount.toLocaleString() }}원
-                  </span>
-                  더 아꼈어요!
+              <div class="flex-1 min-w-0">
+                <p class="text-xs font-bold text-on-surface-variant mb-0.5 font-label">
+                  오늘의 총 지출
+                </p>
+                <p class="text-2xl font-extrabold text-on-surface font-headline leading-none">
+                  {{ totalAmount.toLocaleString() }}원
                 </p>
 
-                <p v-else class="text-xs mt-2">
-                  평균보다
-                  <span class="font-bold text-error">
-                    {{ dailyReport.savedAmount.toLocaleString() }}원
-                  </span>
-                  더 썼어요 😢
-                </p>
+                <div class="mt-2.5 pt-2.5 border-t border-outline-variant/40">
+                  <p v-if="dailyReport.isSaved" class="text-xs font-semibold text-on-surface-variant">
+                    평균보다
+                    <span class="font-bold text-secondary">
+                      {{ dailyReport.savedAmount.toLocaleString() }}원
+                    </span>
+                    더 아꼈어요!
+                  </p>
+
+                  <p v-else class="text-xs font-semibold text-on-surface-variant">
+                    평균보다
+                    <span class="font-bold text-error">
+                      {{ dailyReport.savedAmount.toLocaleString() }}원
+                    </span>
+                    더 썼어요 😢
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -246,54 +249,60 @@ const getCategoryIcon = (category: string) => {
   transform: translateX(-50%);
 }
 
+.honey-pot-mask {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C8.69 2 6 4.69 6 8v2c-2.21 0-4 1.79-4 4s1.79 4 4 4h12c2.21 0 4-1.79 4-4s-1.79-4-4-4V8c0-3.31-2.69-6-6-6z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C8.69 2 6 4.69 6 8v2c-2.21 0-4 1.79-4 4s1.79 4 4 4h12c2.21 0 4-1.79 4-4s-1.79-4-4-4V8c0-3.31-2.69-6-6-6z'/%3E%3C/svg%3E");
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-position: center;
+  -webkit-mask-position: center;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+}
+
 .daily-weather {
-  opacity: 0.46;
+  opacity: 0.44;
   isolation: isolate;
   transition:
     opacity 180ms ease,
     transform 180ms ease;
 }
 
+.daily-weather__sun {
+  position: absolute;
+  top: 0.25rem;
+  right: 3.35rem;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 9999px;
+  background: linear-gradient(145deg, #fff3a8 0%, #ffbc50 78%);
+  box-shadow:
+    0 0 0 0.36rem rgba(255, 188, 80, 0.16),
+    0 0.65rem 1.4rem rgba(255, 174, 54, 0.34);
+  opacity: 0;
+  z-index: 1;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.daily-weather__sun::before {
+  content: '';
+  position: absolute;
+  inset: -0.48rem;
+  border-radius: inherit;
+  border: 0.2rem solid rgba(255, 188, 80, 0.24);
+  box-shadow: 0 0 1rem rgba(255, 188, 80, 0.18);
+  z-index: -1;
+}
+
 .daily-weather__cloud {
   position: absolute;
   inset: 0;
-  z-index: 1;
+  z-index: 2;
   transition:
     background-color 180ms ease,
     transform 180ms ease;
-}
-
-.daily-weather__badge {
-  position: absolute;
-  top: 0.1rem;
-  right: 0.1rem;
-  display: grid;
-  place-items: center;
-  width: 2.65rem;
-  height: 2.65rem;
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.86);
-  box-shadow:
-    0 0.55rem 1rem rgba(72, 56, 38, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.72);
-  z-index: 3;
-  transition:
-    color 180ms ease,
-    transform 180ms ease;
-}
-
-.daily-weather__badge--sunny {
-  color: #d98a12;
-  background: rgba(255, 244, 201, 0.92);
-}
-
-.daily-weather__badge--rainy {
-  color: #4f79aa;
-  background: rgba(229, 239, 249, 0.92);
-}
-
-.daily-weather__badge--neutral {
-  color: #7a838d;
 }
 
 .daily-weather__fill,
@@ -301,17 +310,49 @@ const getCategoryIcon = (category: string) => {
   transition: background-color 180ms ease;
 }
 
+.daily-weather__drop {
+  position: absolute;
+  bottom: 0.55rem;
+  width: 0.56rem;
+  height: 0.88rem;
+  border-radius: 9999px 9999px 9999px 0.18rem;
+  background: linear-gradient(145deg, #a7cff6 0%, #5f91c9 78%);
+  box-shadow:
+    0 0 0 0.22rem rgba(95, 145, 201, 0.12),
+    0 0.5rem 0.9rem rgba(95, 145, 201, 0.22);
+  opacity: 0;
+  transform: rotate(38deg) translateY(-0.2rem);
+  z-index: 3;
+  transition: opacity 180ms ease;
+}
+
+.daily-weather__drop--1 {
+  right: 1.65rem;
+}
+
+.daily-weather__drop--2 {
+  right: 2.8rem;
+  bottom: 0.2rem;
+  width: 0.62rem;
+  height: 1rem;
+}
+
+.daily-weather__drop--3 {
+  right: 4.05rem;
+}
+
 .daily-weather--sunny {
   opacity: 0.72;
 }
 
-.daily-weather--sunny .daily-weather__cloud {
-  background-color: #ffe0a0;
-  transform: translate(0.25rem, 0.55rem) scale(0.82);
+.daily-weather--sunny .daily-weather__sun {
+  opacity: 1;
+  transform: scale(1);
 }
 
-.daily-weather--sunny .daily-weather__badge {
-  transform: translate(-0.15rem, -0.1rem);
+.daily-weather--sunny .daily-weather__cloud {
+  background-color: #ffe0a0;
+  transform: translate(0.25rem, 0.1rem) scale(0.84);
 }
 
 .daily-weather--rainy {
@@ -320,7 +361,7 @@ const getCategoryIcon = (category: string) => {
 
 .daily-weather--rainy .daily-weather__cloud {
   background-color: #8794a1;
-  transform: translate(0.1rem, 0.25rem) scale(0.86);
+  transform: translate(0.1rem, -0.35rem) scale(0.92);
 }
 
 .daily-weather--rainy .daily-weather__fill,
@@ -328,8 +369,32 @@ const getCategoryIcon = (category: string) => {
   background-color: #5f7286;
 }
 
+.daily-weather--rainy .daily-weather__drop {
+  opacity: 1;
+  animation: weather-rain-fall 1.15s ease-in-out infinite;
+}
+
+.daily-weather--rainy .daily-weather__drop--2 {
+  animation-delay: 0.18s;
+}
+
+.daily-weather--rainy .daily-weather__drop--3 {
+  animation-delay: 0.34s;
+}
+
 .daily-weather--neutral .daily-weather__cloud {
-  transform: scale(0.88);
+  transform: translateY(-0.6rem) scale(0.94);
+}
+
+@keyframes weather-rain-fall {
+  0%,
+  100% {
+    transform: rotate(38deg) translateY(-0.2rem);
+  }
+
+  50% {
+    transform: rotate(38deg) translateY(0.28rem);
+  }
 }
 
 /* 아이콘 통일 핵심 */

--- a/src/components/CalendarDetail.vue
+++ b/src/components/CalendarDetail.vue
@@ -147,7 +147,11 @@ const getCategoryIcon = (category: string) => {
               <div class="relative z-10">
                 <div class="flex flex-col items-start">
                   <p class="text-on-surface-variant text-[13px] font-bold mb-2 font-label">
-                    일평균 생활비를 아껴서
+                    {{
+                      dailyReport.isSaved
+                        ? '일평균 생활비를 아껴서'
+                        : '일평균 생활비보다 많이 써서'
+                    }}
                   </p>
                   <p class="text-[32px] font-extrabold text-secondary font-headline leading-tight">
                     {{ dailyReport.stockName }} {{ dailyReport.securedQuantity }}주

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -76,8 +76,7 @@ const todayExpenseTotal = computed(() =>
 )
 const todayExpenseStockQuantity = computed(() => {
   if (!targetStockPrice.value) return '0.00'
-  const diffFromAverage = budgetStore.dailyAverage - todayExpenseTotal.value
-  return (diffFromAverage / targetStockPrice.value).toFixed(2)
+  return (todayExpenseTotal.value / targetStockPrice.value).toFixed(2)
 })
 const recentItems = computed(() =>
   budgetStore.recentExpenses.slice(0, visibleHistoryCount.value).map((expense) => ({
@@ -252,7 +251,7 @@ async function handleExpenseSave(payload) {
             {{ targetStockTicker || '주식' }}
           </div>
           <div class="stock-copy">
-            <p class="stock-label">일평균 대비 오늘의 주식 환산</p>
+            <p class="stock-label">오늘 지출 주식 환산</p>
             <p class="stock-value">
               {{ targetStockName || '주식' }}
               {{ todayExpenseStockQuantity }}주

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -28,8 +28,6 @@ const budgetStore = useBudgetStore()
 // storeToRefs를 써야 반응형이 유지되어서 꿀단지가 부드럽게 움직입니다!
 const {
   expenses,
-  remainingBudget,
-  fillPercentage,
   guidelinePercentage,
   targetStockName,
   targetStockTicker,
@@ -59,11 +57,18 @@ onMounted(async () => {
 })
 
 const visibleHistoryCount = ref(INITIAL_HISTORY_COUNT)
+const currentMonthKey = computed(() => currentMonth.value.format('YYYY-MM'))
 const selectedDateKey = computed(() => selectedDate.value.format('YYYY-MM-DD'))
 const todayDateKey = computed(() => dayjs().format('YYYY-MM-DD'))
 const expenseDateSet = computed(() => new Set(expenses.value.map((expense) => expense.date)))
 const selectedDayExpenses = computed(() => budgetStore.getExpensesByDate(selectedDateKey.value))
 const calendarDailyReport = computed(() => budgetStore.getDailyReport(selectedDateKey.value))
+const monthlyRemainingBudget = computed(() =>
+  budgetStore.getMonthlyRemainingBudget(currentMonthKey.value),
+)
+const monthlyFillPercentage = computed(() =>
+  budgetStore.getMonthlyFillPercentage(currentMonthKey.value),
+)
 const todayExpenseTotal = computed(() =>
   budgetStore
     .getExpensesByDate(todayDateKey.value)
@@ -227,17 +232,17 @@ async function handleExpenseSave(payload) {
           <div class="bee-slot" aria-hidden="true">
             <div class="honey-pot-stage">
               <HoneyPot
-                :display-value="Math.floor(fillPercentage)"
-                :fill-percentage="fillPercentage"
+                :display-value="Math.floor(monthlyFillPercentage)"
+                :fill-percentage="monthlyFillPercentage"
                 :guideline-percentage="guidelinePercentage"
               />
             </div>
           </div>
 
           <div class="balance-copy">
-            <p class="balance-label">이번 달 생활비 남음</p>
-            <p class="balance-amount">₩{{ remainingBudget.toLocaleString() }}</p>
-            <p class="balance-hint">빨간 선은 목표 주식 가격</p>
+            <p class="balance-label">이 달 생활비 남음</p>
+            <p class="balance-amount">₩{{ monthlyRemainingBudget.toLocaleString() }}</p>
+            <p class="balance-hint">빨간 선은 목표 주식 총 금액</p>
             <p class="balance-hint">꿀단지는 현재 남은 생활비를 비율을 보여줘요</p>
           </div>
         </section>
@@ -247,7 +252,7 @@ async function handleExpenseSave(payload) {
             {{ targetStockTicker || '주식' }}
           </div>
           <div class="stock-copy">
-            <p class="stock-label">오늘 쓴 돈으로 살 수 있었던 주식</p>
+            <p class="stock-label">일평균 대비 오늘의 주식 환산</p>
             <p class="stock-value">
               {{ targetStockName || '주식' }}
               {{ todayExpenseStockQuantity }}주

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -10,196 +10,15 @@ import { storeToRefs } from 'pinia'
 import { useBudgetStore } from '@/stores/useBudgetStore'
 const weekdays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 
-const calendarAccentMap = {
-  '2024-05-01': 'soft',
-  '2024-05-02': 'warm',
-  '2024-05-03': 'accent',
-  '2024-05-04': 'dark',
-  '2024-05-05': 'soft',
-  '2024-05-06': 'dark',
-  '2024-05-07': 'warm',
-  '2024-05-08': 'soft',
-  '2024-05-09': 'warm',
-  '2024-05-10': 'dark',
-  '2024-05-11': 'soft',
-  '2024-05-13': 'soft',
-  '2024-05-15': 'warm',
-  '2024-05-18': 'dark',
-  '2024-05-19': 'soft',
-  '2024-05-21': 'warm',
-  '2024-05-24': 'dark',
-  '2024-05-28': 'soft',
-  '2024-05-30': 'warm',
-}
+const calendarDotTones = ['soft', 'warm', 'accent', 'dark']
+const INITIAL_HISTORY_COUNT = 3
+const HISTORY_INCREMENT = 10
 
 const currentMonth = ref(dayjs().startOf('month'))
 const selectedDate = ref(dayjs())
 const isCalendarDetailOpen = ref(false)
 const isExpenseInputOpen = ref(false)
 const reopenCalendarDetail = ref(false)
-
-const historyItems = [
-  {
-    id: 1,
-    name: '스타벅스 강남점',
-    meta: '오늘 2:15 • 식비/카페',
-    amount: '-₩5,400',
-    type: 'expense',
-    icon: 'meal',
-  },
-  {
-    id: 2,
-    name: '주식 자동 투자',
-    meta: '오늘 9:00 • 투자',
-    amount: '+₩10,000',
-    type: 'income',
-    icon: 'stock',
-  },
-  {
-    id: 3,
-    name: 'CU 편의점',
-    meta: '어제 • 편의점',
-    amount: '-₩2,100',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 4,
-    name: '마켓컬리',
-    meta: '어제 7:40 • 장보기',
-    amount: '-₩34,800',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 5,
-    name: '네이버페이 환급',
-    meta: '5월 1일 • 적립/환급',
-    amount: '+₩3,200',
-    type: 'income',
-    icon: 'stock',
-  },
-  {
-    id: 6,
-    name: '메가커피',
-    meta: '4월 30일 • 식비/카페',
-    amount: '-₩3,000',
-    type: 'expense',
-    icon: 'meal',
-  },
-  {
-    id: 7,
-    name: '올리브영',
-    meta: '4월 30일 • 자기관리',
-    amount: '-₩18,500',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 8,
-    name: '자동 투자 리워드',
-    meta: '4월 29일 • 투자',
-    amount: '+₩8,000',
-    type: 'income',
-    icon: 'stock',
-  },
-  {
-    id: 9,
-    name: '배달의민족',
-    meta: '4월 29일 • 배달/야식',
-    amount: '-₩22,000',
-    type: 'expense',
-    icon: 'meal',
-  },
-  {
-    id: 10,
-    name: 'GS25',
-    meta: '4월 28일 • 편의점',
-    amount: '-₩4,700',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 11,
-    name: '삼성증권 자동이체',
-    meta: '4월 28일 • 투자',
-    amount: '+₩50,000',
-    type: 'income',
-    icon: 'stock',
-  },
-  {
-    id: 12,
-    name: '지하철',
-    meta: '4월 27일 • 교통',
-    amount: '-₩1,400',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 13,
-    name: '컴포즈커피',
-    meta: '4월 27일 • 식비/카페',
-    amount: '-₩2,800',
-    type: 'expense',
-    icon: 'meal',
-  },
-  {
-    id: 14,
-    name: '쿠팡',
-    meta: '4월 26일 • 쇼핑',
-    amount: '-₩17,900',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 15,
-    name: '토스 환급',
-    meta: '4월 26일 • 적립/환급',
-    amount: '+₩1,500',
-    type: 'income',
-    icon: 'stock',
-  },
-  {
-    id: 16,
-    name: '파리바게뜨',
-    meta: '4월 25일 • 식비/카페',
-    amount: '-₩6,300',
-    type: 'expense',
-    icon: 'meal',
-  },
-  {
-    id: 17,
-    name: '이마트24',
-    meta: '4월 25일 • 편의점',
-    amount: '-₩3,900',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 18,
-    name: '적금 만기 이자',
-    meta: '4월 24일 • 금융',
-    amount: '+₩12,400',
-    type: 'income',
-    icon: 'stock',
-  },
-  {
-    id: 19,
-    name: '올영세일',
-    meta: '4월 24일 • 자기관리',
-    amount: '-₩27,000',
-    type: 'expense',
-    icon: 'bag',
-  },
-  {
-    id: 20,
-    name: '버거킹',
-    meta: '4월 23일 • 식비',
-    amount: '-₩8,900',
-    type: 'expense',
-    icon: 'meal',
-  },
-]
 
 const calendarTitle = computed(
   () => `${currentMonth.value.year()}년 ${currentMonth.value.month() + 1}월`,
@@ -239,9 +58,7 @@ onMounted(async () => {
   }
 })
 
-const visibleHistoryCount = ref(3)
-const recentItems = computed(() => historyItems.slice(0, visibleHistoryCount.value))
-const canLoadMoreHistory = computed(() => visibleHistoryCount.value < historyItems.length)
+const visibleHistoryCount = ref(INITIAL_HISTORY_COUNT)
 const selectedDateKey = computed(() => selectedDate.value.format('YYYY-MM-DD'))
 const todayDateKey = computed(() => dayjs().format('YYYY-MM-DD'))
 const expenseDateSet = computed(() => new Set(expenses.value.map((expense) => expense.date)))
@@ -257,6 +74,46 @@ const todayExpenseStockQuantity = computed(() => {
   const diffFromAverage = budgetStore.dailyAverage - todayExpenseTotal.value
   return (diffFromAverage / targetStockPrice.value).toFixed(2)
 })
+const recentItems = computed(() =>
+  budgetStore.recentExpenses.slice(0, visibleHistoryCount.value).map((expense) => ({
+    id: expense.id,
+    name: expense.memo || expense.category,
+    meta: formatHistoryMeta(expense),
+    amount: `-${expense.amount.toLocaleString()}원`,
+    type: 'expense',
+    iconUrl: expense.categoryImageUrl || '/images/categories/shopping.png',
+  })),
+)
+const canLoadMoreHistory = computed(
+  () => visibleHistoryCount.value < budgetStore.recentExpenses.length,
+)
+
+function formatHistoryDate(date) {
+  const historyDate = dayjs(date)
+  if (!historyDate.isValid()) return ''
+
+  const today = dayjs()
+  if (historyDate.isSame(today, 'day')) return '오늘'
+  if (historyDate.isSame(today.subtract(1, 'day'), 'day')) return '어제'
+  if (historyDate.isSame(today, 'year')) return historyDate.format('M월 D일')
+  return historyDate.format('YYYY. M. D')
+}
+
+function formatHistoryMeta(expense) {
+  const dateTime = [formatHistoryDate(expense.date), expense.time].filter(Boolean).join(' ')
+  return [dateTime, expense.category].filter(Boolean).join(' • ')
+}
+
+function getCalendarDotTone(date) {
+  const [firstExpense] = budgetStore.getExpensesByDate(date)
+  if (!firstExpense) return null
+
+  const toneSource = Number(firstExpense.categoryId ?? firstExpense.id ?? 1)
+  const toneIndex = Number.isFinite(toneSource)
+    ? Math.abs(toneSource - 1) % calendarDotTones.length
+    : 0
+  return calendarDotTones[toneIndex]
+}
 
 const calendarDays = computed(() => {
   const monthStart = currentMonth.value.startOf('month')
@@ -277,7 +134,7 @@ const calendarDays = computed(() => {
       key: isoDate,
       label: date.date(),
       isoDate,
-      dotTone: expenseDateSet.value.has(isoDate) ? (calendarAccentMap[isoDate] ?? 'warm') : null,
+      dotTone: expenseDateSet.value.has(isoDate) ? getCalendarDotTone(isoDate) : null,
       inCurrentMonth,
       isSelected: date.isSame(selectedDate.value, 'day'),
       isToday: date.isSame(dayjs(), 'day'),
@@ -311,7 +168,10 @@ function handleStockClick() {
 }
 
 function loadMoreHistory() {
-  visibleHistoryCount.value = Math.min(historyItems.length, visibleHistoryCount.value + 10)
+  visibleHistoryCount.value = Math.min(
+    budgetStore.recentExpenses.length,
+    visibleHistoryCount.value + HISTORY_INCREMENT,
+  )
 }
 
 function openCalendarDetail(isoDate) {
@@ -441,18 +301,12 @@ async function handleExpenseSave(payload) {
             <p>최근 소비 내역</p>
           </div>
 
-          <div class="history-list">
+          <p v-if="recentItems.length === 0" class="history-empty">아직 소비 내역이 없어요</p>
+
+          <div v-else class="history-list">
             <article v-for="item in recentItems" :key="item.id" class="history-card">
               <div class="history-icon">
-                <svg v-if="item.icon === 'meal'" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M7 3v8M10 3v8M7 7h3M15 3v18M18 3c0 3-1 5-3 5" />
-                </svg>
-                <svg v-else-if="item.icon === 'stock'" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M4 16l5-5 4 3 7-7M16 7h4v4" />
-                </svg>
-                <svg v-else viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M6 8h12l-1 11H7L6 8zm3 0V7a3 3 0 016 0v1" />
-                </svg>
+                <img :src="item.iconUrl" :alt="item.name" class="history-icon-image" />
               </div>
 
               <div class="history-copy">
@@ -841,6 +695,19 @@ async function handleExpenseSave(payload) {
   gap: 1rem;
 }
 
+.history-empty {
+  margin: 1.2rem 0 0;
+  padding: 1.15rem;
+  border-radius: var(--radius-card);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow-card);
+  color: #8a8179;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
 .history-more-button {
   display: block;
   width: fit-content;
@@ -887,14 +754,11 @@ async function handleExpenseSave(payload) {
   box-shadow: var(--shadow-soft);
 }
 
-.history-icon svg {
-  width: 1.9rem;
-  height: 1.9rem;
-  fill: none;
-  stroke: #6f6253;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 1.8;
+.history-icon-image {
+  width: 2.35rem;
+  height: 2.35rem;
+  object-fit: cover;
+  border-radius: 999px;
 }
 
 .history-copy {

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -78,6 +78,7 @@ const todayExpenseStockQuantity = computed(() => {
   if (!targetStockPrice.value) return '0.00'
   return (todayExpenseTotal.value / targetStockPrice.value).toFixed(2)
 })
+const hasTodayExpense = computed(() => todayExpenseTotal.value > 0)
 const recentItems = computed(() =>
   budgetStore.recentExpenses.slice(0, visibleHistoryCount.value).map((expense) => ({
     id: expense.id,
@@ -252,10 +253,11 @@ async function handleExpenseSave(payload) {
           </div>
           <div class="stock-copy">
             <p class="stock-label">오늘 지출 주식 환산</p>
-            <p class="stock-value">
+            <p v-if="hasTodayExpense" class="stock-value">
               {{ targetStockName || '주식' }}
               {{ todayExpenseStockQuantity }}주
             </p>
+            <p v-else class="stock-value stock-value--empty">오늘 지출이 아직 없습니다!</p>
           </div>
         </section>
 

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -503,6 +503,14 @@ async function handleExpenseSave(payload) {
   letter-spacing: -0.05em;
 }
 
+.stock-value--empty {
+  color: #8a8179;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.35;
+}
+
 .stock-arrow-button {
   display: grid;
   place-items: center;

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -119,8 +119,8 @@ export const useBudgetStore = defineStore('budget', {
     },
 
     guidelinePercentage(state) {
-      if (state.budget <= 0 || this.targetStockPrice <= 0) return 0
-      const ratio = (this.targetStockPrice / state.budget) * 100
+      if (state.budget <= 0 || this.targetTotalAmount <= 0) return 0
+      const ratio = (this.targetTotalAmount / state.budget) * 100
       return Math.min(Math.max(ratio, 0), 100)
     },
 
@@ -179,6 +179,8 @@ export const useBudgetStore = defineStore('budget', {
         ...expense,
         amount: toNumber(expense.amount),
         category: expense.category ?? category?.name ?? '기타',
+        categoryImageUrl:
+          expense.categoryImageUrl ?? category?.imageUrl ?? '/images/categories/shopping.png',
         date: expense.date ?? toDateKey(expense.spentAt),
         time: expense.time ?? toTimeKey(expense.spentAt),
         memo: expense.memo ?? '',

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -108,6 +108,30 @@ export const useBudgetStore = defineStore('budget', {
       return (date) => this.expensesByDate[date] ?? []
     },
 
+    getExpensesByMonth() {
+      return (monthKey) =>
+        this.expenses.filter(
+          (expense) => typeof expense.date === 'string' && expense.date.startsWith(monthKey),
+        )
+    },
+
+    getMonthlyExpenseTotal() {
+      return (monthKey) =>
+        this.getExpensesByMonth(monthKey).reduce((sum, expense) => sum + expense.amount, 0)
+    },
+
+    getMonthlyRemainingBudget(state) {
+      return (monthKey) => state.budget - this.getMonthlyExpenseTotal(monthKey)
+    },
+
+    getMonthlyFillPercentage(state) {
+      return (monthKey) => {
+        if (state.budget <= 0) return 0
+        const ratio = (this.getMonthlyRemainingBudget(monthKey) / state.budget) * 100
+        return Math.min(Math.max(ratio, 0), 100)
+      }
+    },
+
     remainingBudget(state) {
       return state.budget - this.totalExpense
     },


### PR DESCRIPTION
## 🐛 Bug | 수정 내용
홈 화면의 예산/지출 데이터 연동 기준을 실제 로그인 사용자 및 월별 데이터 기준으로 정리하고, 꿀통 목표 기준선 계산 오류를 수정했습니다.

## 🔧 작업 내용
- 홈 화면 생활비 잔액/꿀통 채움 비율을 전체 지출이 아닌 현재 월 지출 기준으로 계산하도록 수정
- 꿀통 빨간 기준선을 목표 주식 1주 가격이 아닌 목표 주식 가격 × 목표 수량 기준으로 계산
- 최근 소비 내역, 캘린더 지출 표시, 일일 리포트 데이터를 Pinia 예산 스토어 기반으로 연동
- 오늘 지출 주식 환산 카드에서 지출이 없을 때 빈 상태 문구 표시
- 일일 리포트의 절약/초과 지출 문구와 주식 환산 표시 정리
- 해/구름/비 날씨 UI를 CSS 스타일 기반으로 복구하고 구름 마스크 누락 문제 수정
- 일일 요약의 오늘의 총 지출 영역을 카드 형태로 다시 보이도록 UI 보정
- 홈 화면 데이터 검증을 위한 지출 fixture 추가

## ✅ 검증
- `npm run validate:db`
- `npm run build`
- `git diff --check`

## 📌 참고
- 리포트 페이지는 이번 작업 범위에서 수정하지 않았습니다.
- Vite 빌드 시 기존 chunk size warning은 발생하지만 빌드는 정상 완료됩니다.
