### PR TITLE
fix: 사용자 세션 기반 데이터 흐름 및 홈/리포트 연동 안정화

### DIFF
--- a/db.json
+++ b/db.json
@@ -446,6 +446,22 @@
       "memo": "피자",
       "spentAt": "2026-04-04T14:58:00",
       "id": 39
+    },
+    {
+      "memberId": 2,
+      "categoryId": 1,
+      "amount": 4000,
+      "memo": "학식",
+      "spentAt": "2026-04-10T15:27:00",
+      "id": 40
+    },
+    {
+      "memberId": 2,
+      "categoryId": 2,
+      "amount": 1500,
+      "memo": "컴포즈",
+      "spentAt": "2026-04-10T15:27:00",
+      "id": 41
     }
   ],
   "reports": [

--- a/db.json
+++ b/db.json
@@ -5,9 +5,9 @@
       "name": "진승환",
       "birthdate": "20020918",
       "password": "abcd1234!",
-      "monthlyBudget": 0,
-      "targetStockId": null,
-      "targetQuantity": 0,
+      "monthlyBudget": 1000000,
+      "targetStockId": 2,
+      "targetQuantity": 2,
       "ageBand": "TWENTIES",
       "id": 1
     },
@@ -462,6 +462,238 @@
       "memo": "컴포즈",
       "spentAt": "2026-04-10T15:27:00",
       "id": 41
+    },
+    {
+      "id": 42,
+      "memberId": 1,
+      "categoryId": 2,
+      "amount": 8500,
+      "memo": "출근길 라떼",
+      "spentAt": "2026-03-02T08:35:00"
+    },
+    {
+      "id": 43,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 29000,
+      "memo": "야식 피자 배달",
+      "spentAt": "2026-03-02T22:40:00"
+    },
+    {
+      "id": 44,
+      "memberId": 1,
+      "categoryId": 4,
+      "amount": 45000,
+      "memo": "세일 알림 충동구매",
+      "spentAt": "2026-03-03T21:10:00"
+    },
+    {
+      "id": 45,
+      "memberId": 1,
+      "categoryId": 1,
+      "amount": 14000,
+      "memo": "점심 외식",
+      "spentAt": "2026-03-04T12:20:00"
+    },
+    {
+      "id": 46,
+      "memberId": 1,
+      "categoryId": 4,
+      "amount": 78000,
+      "memo": "새벽 한정판 후드티",
+      "spentAt": "2026-03-05T23:10:00"
+    },
+    {
+      "id": 47,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 32000,
+      "memo": "퇴근 후 치킨",
+      "spentAt": "2026-03-06T20:30:00"
+    },
+    {
+      "id": 48,
+      "memberId": 1,
+      "categoryId": 5,
+      "amount": 44000,
+      "memo": "즉흥 방탈출",
+      "spentAt": "2026-03-07T15:00:00"
+    },
+    {
+      "id": 49,
+      "memberId": 1,
+      "categoryId": 2,
+      "amount": 12000,
+      "memo": "디저트 카페",
+      "spentAt": "2026-03-08T16:30:00"
+    },
+    {
+      "id": 50,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 31000,
+      "memo": "마라탕 배달",
+      "spentAt": "2026-03-09T23:20:00"
+    },
+    {
+      "id": 51,
+      "memberId": 1,
+      "categoryId": 8,
+      "amount": 42000,
+      "memo": "헤어 시술 예약",
+      "spentAt": "2026-03-10T20:50:00"
+    },
+    {
+      "id": 52,
+      "memberId": 1,
+      "categoryId": 4,
+      "amount": 69000,
+      "memo": "라이브커머스 즉시 결제",
+      "spentAt": "2026-03-11T22:30:00"
+    },
+    {
+      "id": 53,
+      "memberId": 1,
+      "categoryId": 6,
+      "amount": 16000,
+      "memo": "편의점 야식 묶음",
+      "spentAt": "2026-03-12T01:15:00"
+    },
+    {
+      "id": 54,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 38000,
+      "memo": "친구 따라 배달",
+      "spentAt": "2026-03-13T21:40:00"
+    },
+    {
+      "id": 55,
+      "memberId": 1,
+      "categoryId": 5,
+      "amount": 35000,
+      "memo": "주말 영화 굿즈",
+      "spentAt": "2026-03-14T14:20:00"
+    },
+    {
+      "id": 56,
+      "memberId": 1,
+      "categoryId": 9,
+      "amount": 19900,
+      "memo": "게임 패스 자동결제",
+      "spentAt": "2026-03-15T02:10:00"
+    },
+    {
+      "id": 57,
+      "memberId": 1,
+      "categoryId": 1,
+      "amount": 18000,
+      "memo": "혼밥 대신 프랜차이즈",
+      "spentAt": "2026-03-16T19:45:00"
+    },
+    {
+      "id": 58,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 33000,
+      "memo": "늦은 밤 족발 배달",
+      "spentAt": "2026-03-18T23:40:00"
+    },
+    {
+      "id": 59,
+      "memberId": 1,
+      "categoryId": 4,
+      "amount": 77000,
+      "memo": "운동화 충동구매",
+      "spentAt": "2026-03-19T21:10:00"
+    },
+    {
+      "id": 60,
+      "memberId": 1,
+      "categoryId": 7,
+      "amount": 28000,
+      "memo": "심야 택시",
+      "spentAt": "2026-03-20T00:30:00"
+    },
+    {
+      "id": 61,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 34000,
+      "memo": "주말 떡볶이 세트",
+      "spentAt": "2026-03-22T19:45:00"
+    },
+    {
+      "id": 62,
+      "memberId": 1,
+      "categoryId": 4,
+      "amount": 48000,
+      "memo": "추천템 바로구매",
+      "spentAt": "2026-03-24T22:00:00"
+    },
+    {
+      "id": 63,
+      "memberId": 1,
+      "categoryId": 2,
+      "amount": 10500,
+      "memo": "프라페와 케이크",
+      "spentAt": "2026-03-26T15:30:00"
+    },
+    {
+      "id": 64,
+      "memberId": 1,
+      "categoryId": 5,
+      "amount": 37000,
+      "memo": "즉흥 보드게임 모임",
+      "spentAt": "2026-03-28T17:50:00"
+    },
+    {
+      "id": 65,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 20000,
+      "memo": "월말 야식",
+      "spentAt": "2026-03-31T23:10:00"
+    },
+    {
+      "id": 66,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 36000,
+      "memo": "새달 첫 야식",
+      "spentAt": "2026-04-01T22:10:00"
+    },
+    {
+      "id": 67,
+      "memberId": 1,
+      "categoryId": 4,
+      "amount": 128000,
+      "memo": "한정판 운동화",
+      "spentAt": "2026-04-03T19:00:00"
+    },
+    {
+      "id": 68,
+      "memberId": 1,
+      "categoryId": 2,
+      "amount": 9500,
+      "memo": "디저트 카페",
+      "spentAt": "2026-04-05T16:20:00"
+    },
+    {
+      "id": 69,
+      "memberId": 1,
+      "categoryId": 5,
+      "amount": 62000,
+      "memo": "게임 아이템 결제",
+      "spentAt": "2026-04-07T23:05:00"
+    },
+    {
+      "id": 70,
+      "memberId": 1,
+      "categoryId": 3,
+      "amount": 28000,
+      "memo": "퇴근 후 치킨",
+      "spentAt": "2026-04-10T21:15:00"
     }
   ],
   "reports": [
@@ -538,6 +770,82 @@
           "categoryImageUrl": "/images/categories/delivery.png",
           "amount": 76000,
           "additionalQuantity": 1.73
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "memberId": 1,
+      "targetMonth": "2026-03",
+      "dailyExpenses": [
+        {
+          "day": "월",
+          "amount": 86500
+        },
+        {
+          "day": "화",
+          "amount": 155000
+        },
+        {
+          "day": "수",
+          "amount": 116000
+        },
+        {
+          "day": "목",
+          "amount": 181500
+        },
+        {
+          "day": "금",
+          "amount": 98000
+        },
+        {
+          "day": "토",
+          "amount": 116000
+        },
+        {
+          "day": "일",
+          "amount": 65900
+        }
+      ],
+      "memberName": "진승환",
+      "ageBand": "TWENTIES",
+      "stockId": 2,
+      "stockName": "삼성전자",
+      "stockPriceSnapshot": 210500,
+      "monthlyBudget": 1000000,
+      "monthlyExpenseTotal": 818900,
+      "savedAmount": 181100,
+      "securedQuantity": 0.86,
+      "targetQuantity": 2,
+      "progressRate": 43,
+      "peerPercentile": 18,
+      "successCount": 7,
+      "summaryComment": "3월에는 온라인 쇼핑과 배달, 즉흥 취미 결제가 반복되면서 삼성전자 2주 목표에 필요한 절약액을 채우지 못했어요.",
+      "opportunityMessage": "이번 달 아낀 금액으로 삼성전자 0.86주 확보에 그쳐 2주 목표에 도달하지 못했어요.",
+      "topCategories": [
+        {
+          "rank": 1,
+          "categoryId": 4,
+          "categoryName": "쇼핑",
+          "categoryImageUrl": "/images/categories/shopping.png",
+          "amount": 317000,
+          "additionalQuantity": 1.51
+        },
+        {
+          "rank": 2,
+          "categoryId": 3,
+          "categoryName": "배달/야식",
+          "categoryImageUrl": "/images/categories/delivery.png",
+          "amount": 217000,
+          "additionalQuantity": 1.03
+        },
+        {
+          "rank": 3,
+          "categoryId": 5,
+          "categoryName": "취미/여가",
+          "categoryImageUrl": "/images/categories/hobby.png",
+          "amount": 116000,
+          "additionalQuantity": 0.55
         }
       ]
     }

--- a/index.css
+++ b/index.css
@@ -10,3 +10,106 @@
   --color-outline-variant: #d0c5ba;
   --color-error: #ba1a1a;
 }
+
+/*
+  Global scrollbar themes.
+  Switch with: document.documentElement.dataset.scrollbarTheme = 'honey' | 'brown' | 'cream' | 'minimal' | 'contextual'
+*/
+:root {
+  --scrollbar-size: 7px;
+  --scrollbar-radius: 999px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: rgba(75, 68, 51, 0.2);
+  --scrollbar-thumb-hover: rgba(75, 68, 51, 0.42);
+  --scrollbar-thumb-active: rgba(75, 68, 51, 0.58);
+  --scrollbar-border: 2px solid transparent;
+}
+
+:root[data-scrollbar-theme='honey'] {
+  --scrollbar-size: 8px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: #d8c8ad;
+  --scrollbar-thumb-hover: #c5ad86;
+  --scrollbar-thumb-active: #b79b70;
+  --scrollbar-border: 2px solid transparent;
+}
+
+:root[data-scrollbar-theme='brown'] {
+  --scrollbar-size: 8px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: rgba(91, 73, 57, 0.45);
+  --scrollbar-thumb-hover: rgba(91, 73, 57, 0.7);
+  --scrollbar-thumb-active: rgba(91, 73, 57, 0.86);
+  --scrollbar-border: 2px solid transparent;
+}
+
+:root[data-scrollbar-theme='cream'] {
+  --scrollbar-size: 9px;
+  --scrollbar-track: #fff4dd;
+  --scrollbar-thumb: #cdbb9d;
+  --scrollbar-thumb-hover: #bfa87e;
+  --scrollbar-thumb-active: #aa9168;
+  --scrollbar-border: 2px solid #fff4dd;
+}
+
+:root[data-scrollbar-theme='minimal'] {
+  --scrollbar-size: 7px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: rgba(75, 68, 51, 0.2);
+  --scrollbar-thumb-hover: rgba(75, 68, 51, 0.42);
+  --scrollbar-thumb-active: rgba(75, 68, 51, 0.58);
+  --scrollbar-border: 2px solid transparent;
+}
+
+:root[data-scrollbar-theme='contextual'] {
+  --scrollbar-size: 8px;
+  --scrollbar-track: #f1f0ed;
+  --scrollbar-thumb: #ffbc50;
+  --scrollbar-thumb-hover: #d79524;
+  --scrollbar-thumb-active: #b97818;
+  --scrollbar-border: 2px solid #f1f0ed;
+}
+
+.app-content,
+.app-content *:not(.global-header):not(.global-header *):not(.bottom-nav):not(.bottom-nav *) {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+.app-content::-webkit-scrollbar,
+.app-content *:not(.global-header):not(.global-header *):not(.bottom-nav):not(.bottom-nav *)::-webkit-scrollbar {
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+}
+
+.app-content::-webkit-scrollbar-track,
+.app-content *:not(.global-header):not(.global-header *):not(.bottom-nav):not(.bottom-nav *)::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+  border-radius: var(--scrollbar-radius);
+}
+
+.app-content::-webkit-scrollbar-thumb,
+.app-content *:not(.global-header):not(.global-header *):not(.bottom-nav):not(.bottom-nav *)::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border: var(--scrollbar-border);
+  border-radius: var(--scrollbar-radius);
+  background-clip: padding-box;
+}
+
+.app-content::-webkit-scrollbar-thumb:hover,
+.app-content *:not(.global-header):not(.global-header *):not(.bottom-nav):not(.bottom-nav *)::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
+.app-content::-webkit-scrollbar-thumb:active,
+.app-content *:not(.global-header):not(.global-header *):not(.bottom-nav):not(.bottom-nav *)::-webkit-scrollbar-thumb:active {
+  background-color: var(--scrollbar-thumb-active);
+}
+
+.global-header,
+.global-header *,
+.bottom-nav,
+.bottom-nav * {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}

--- a/src/components/CalendarDetail.vue
+++ b/src/components/CalendarDetail.vue
@@ -6,6 +6,7 @@ interface Expense {
   id: number
   amount: number
   category: string
+  categoryImageUrl?: string
   date: string
   time: string
   memo: string
@@ -18,6 +19,7 @@ interface Props {
   dailyReport: {
     securedQuantity: number
     stockName: string
+    stockTicker?: string
     savedAmount: number
     progressRate: number
     isSaved: boolean
@@ -46,6 +48,7 @@ const weatherLabel = computed(() => {
   if (weatherType.value === 'rainy') return '평균보다 많이 써 비오는 구름 상태'
   return '평균과 비슷해 기본 구름 상태'
 })
+const stockDisplayName = computed(() => props.dailyReport.stockTicker || props.dailyReport.stockName)
 
 const formattedDate = computed(() => {
   if (!props.selectedDate) return ''
@@ -53,7 +56,7 @@ const formattedDate = computed(() => {
   return `${y}년 ${m}월 ${d}일`
 })
 
-const getCategoryIcon = (category: string) => {
+const getCategoryIcon = (expense: Expense) => {
   const iconMap: Record<string, string> = {
     일반식사: '/images/categories/meal.png',
     '카페/음료': '/images/categories/cafe.png',
@@ -65,7 +68,7 @@ const getCategoryIcon = (category: string) => {
     '뷰티/자기관리': '/images/categories/beauty.png',
     '구독/디지털': '/images/categories/digital.png',
   }
-  return iconMap[category] || '/images/categories/shopping.png'
+  return expense.categoryImageUrl || iconMap[expense.category] || '/images/categories/shopping.png'
 }
 </script>
 
@@ -82,14 +85,14 @@ const getCategoryIcon = (category: string) => {
     <Transition name="slide-up">
       <div
         v-if="isOpen"
-        class="calendar-detail-sheet fixed bottom-0 left-1/2 z-[60] flex h-[85vh] w-full max-w-md flex-col overflow-y-auto rounded-t-[2.5rem] border-t border-outline-variant bg-surface-container-lowest shadow-[0_-12px_60px_rgba(45,41,38,0.15)]"
+        class="calendar-detail-sheet fixed bottom-0 left-1/2 z-[60] flex h-[85vh] flex-col overflow-y-auto rounded-t-[2.1rem] border-t border-outline-variant shadow-[0_-12px_60px_rgba(45,41,38,0.15)]"
       >
         <!-- 핸들 -->
-        <div class="w-full flex justify-center py-4 sticky top-0 bg-surface-container-lowest z-10">
-          <div class="w-10 h-1.5 bg-surface-container-highest rounded-full"></div>
+        <div class="calendar-detail-handle w-full flex justify-center py-4 sticky top-0 z-10">
+          <div class="calendar-detail-handle-bar"></div>
         </div>
 
-        <div class="px-6 pb-32">
+        <div class="calendar-detail-content px-5 pb-32">
           <!-- 헤더 -->
           <div class="flex justify-between items-start mb-6">
             <div>
@@ -113,7 +116,8 @@ const getCategoryIcon = (category: string) => {
           <!-- 주식 확보 카드 -->
           <div class="mb-6">
             <div
-              class="bg-surface-container-low border border-outline-variant p-6 rounded-[2.5rem] relative overflow-hidden"
+              class="daily-stock-card relative overflow-hidden"
+              :class="{ 'daily-stock-card--loss': !dailyReport.isSaved }"
             >
               <div
                 class="daily-weather absolute right-4 bottom-4 w-24 h-24 pointer-events-none"
@@ -149,7 +153,7 @@ const getCategoryIcon = (category: string) => {
                     }}
                   </p>
                   <p class="text-[32px] font-extrabold text-secondary font-headline leading-tight">
-                    {{ dailyReport.stockName }} {{ dailyReport.securedQuantity }}주
+                    {{ stockDisplayName }} {{ dailyReport.securedQuantity }}주
                   </p>
                   <p class="text-lg font-bold text-secondary font-headline">
                     {{ dailyReport.isSaved ? '확보했습니다' : '잃었습니다' }}
@@ -160,15 +164,10 @@ const getCategoryIcon = (category: string) => {
           </div>
 
           <!-- 총 지출 -->
-          <div
-            class="bg-surface border border-outline-variant/80 p-5 rounded-2xl mb-10 shadow-[0_10px_28px_rgba(45,41,38,0.06)]"
-          >
+          <div class="daily-total-card">
             <div class="flex items-center gap-4">
-              <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
-                <!-- 🔥 수정된 부분 -->
-                <span class="category-image-mask">
-                  <img src="/images/action/money.png" class="category-image" />
-                </span>
+              <div class="daily-total-icon">
+                <img src="/images/action/money.png" alt="" class="daily-total-icon-image" />
               </div>
 
               <div class="flex-1 min-w-0">
@@ -201,41 +200,32 @@ const getCategoryIcon = (category: string) => {
           </div>
 
           <!-- 거래 내역 -->
-          <section>
-            <div class="flex items-center gap-2 mb-5">
-              <span class="category-image-mask category-image-mask--sm">
-                <img src="/images/action/list.png" class="category-image" />
-              </span>
-
-              <h4 class="text-[16px] font-extrabold">거래 내역</h4>
+          <section class="daily-history-section">
+            <div class="daily-history-heading">
+              <h4>거래 내역</h4>
             </div>
 
-            <div class="space-y-3">
-              <div
+            <p v-if="dayExpenses.length === 0" class="daily-history-empty">이 날의 소비 내역이 없어요</p>
+
+            <div v-else class="daily-history-list">
+              <article
                 v-for="exp in dayExpenses"
                 :key="exp.id"
-                class="flex items-center gap-4 p-4 bg-surface-container-low rounded-2xl"
+                class="daily-history-card"
               >
-                <div class="w-12 h-12 flex items-center justify-center">
-                  <span class="category-image-mask">
-                    <img :src="getCategoryIcon(exp.category)" class="category-image" />
-                  </span>
+                <div class="daily-history-icon">
+                  <img :src="getCategoryIcon(exp)" :alt="exp.category" class="daily-history-icon-image" />
                 </div>
 
-                <div class="flex-1">
-                  <div class="flex justify-between">
-                    <span class="font-bold">{{ exp.category }}</span>
-                    <span class="font-extrabold text-error">
-                      -₩{{ exp.amount.toLocaleString() }}
-                    </span>
-                  </div>
-
-                  <div class="flex justify-between text-sm">
-                    <span>{{ exp.memo }}</span>
-                    <span>{{ exp.time }}</span>
-                  </div>
+                <div class="daily-history-copy">
+                  <p class="daily-history-name">{{ exp.category }}</p>
+                  <p class="daily-history-meta">
+                    {{ [exp.memo, exp.time].filter(Boolean).join(' • ') }}
+                  </p>
                 </div>
-              </div>
+
+                <p class="daily-history-amount">-₩{{ exp.amount.toLocaleString() }}</p>
+              </article>
             </div>
           </section>
         </div>
@@ -246,7 +236,218 @@ const getCategoryIcon = (category: string) => {
 
 <style scoped>
 .calendar-detail-sheet {
+  width: min(100vw, 430px);
+  max-width: min(100vw, 430px);
+  box-sizing: border-box;
+  background: #f9f8f6;
   transform: translateX(-50%);
+}
+
+.calendar-detail-handle {
+  background: #f9f8f6;
+}
+
+.calendar-detail-handle-bar {
+  width: 2.5rem;
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: #d8cec1;
+}
+
+.calendar-detail-content {
+  box-sizing: border-box;
+}
+
+.daily-stock-card {
+  padding: 1.5rem;
+  border: 1px solid #efe7dc;
+  border-radius: 1.6rem;
+  background: #fff4dd;
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+.daily-stock-card--loss {
+  border-color: #e7e3de;
+  background: #f1f0ed;
+  box-shadow: 0 0.75rem 1.6rem rgba(72, 56, 38, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.66);
+}
+
+.daily-total-card {
+  margin-bottom: 2.5rem;
+  padding: 1.25rem;
+  border: 1px solid #efe7dc;
+  border-radius: 1.1rem;
+  background: #ffffff;
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.daily-total-icon {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.daily-total-icon-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.daily-history-section {
+  width: 100%;
+}
+
+.daily-history-heading {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: 1.2rem;
+  padding-left: 0.25rem;
+}
+
+.daily-history-heading h4 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: #1d1814;
+}
+
+.daily-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.daily-history-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1rem;
+  border: 1px solid #efe7dc;
+  border-radius: 1.1rem;
+  background: #ffffff;
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.daily-history-icon {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.daily-history-icon-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.daily-history-copy {
+  min-width: 0;
+}
+
+.daily-history-name,
+.daily-history-meta,
+.daily-history-amount {
+  margin: 0;
+}
+
+.daily-history-name {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: #1d1814;
+}
+
+.daily-history-meta {
+  margin-top: 0.25rem;
+  color: #aba29b;
+  font-size: 0.86rem;
+  line-height: 1.35;
+  letter-spacing: -0.03em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.daily-history-amount {
+  color: #191411;
+  font-size: 1rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+.daily-history-empty {
+  margin: 0;
+  padding: 1.15rem;
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07);
+  color: #8a8179;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
+.slide-up-enter-active {
+  transition:
+    opacity 0.24s ease,
+    transform 0.42s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.slide-up-leave-active {
+  transition:
+    opacity 0.18s ease,
+    transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.slide-up-enter-from,
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(100%);
+}
+
+.slide-up-enter-to,
+.slide-up-leave-from {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.fade-enter-active {
+  transition: opacity 0.15s ease-out;
+}
+
+.fade-leave-active {
+  transition: opacity 0.12s ease-in;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.fade-enter-to,
+.fade-leave-from {
+  opacity: 1;
 }
 
 .honey-pot-mask {
@@ -397,27 +598,14 @@ const getCategoryIcon = (category: string) => {
   }
 }
 
-/* 아이콘 통일 핵심 */
-.category-image-mask {
-  width: 1.9rem;
-  height: 1.9rem;
-  border-radius: 9999px;
-  overflow: hidden;
-  background: rgba(255, 188, 80, 0.16);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+@media (max-width: 430px) {
+  .daily-stock-card {
+    border-radius: 1.35rem;
+    padding: 1.25rem;
+  }
 
-.category-image-mask--sm {
-  width: 1.4rem;
-  height: 1.4rem;
-}
-
-.category-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transform: scale(1.1);
+  .daily-history-card {
+    gap: 0.85rem;
+  }
 }
 </style>

--- a/src/components/ExpenseInput.vue
+++ b/src/components/ExpenseInput.vue
@@ -586,9 +586,9 @@ const handleSave = () => {
   left: 50%;
   width: min(100vw, 430px);
   height: min(100vh, 932px);
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(44, 36, 28, 0.28);
   z-index: 80;
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(3px);
   transform: translateX(-50%);
 }
 
@@ -599,12 +599,13 @@ const handleSave = () => {
   transform: translateX(-50%);
   width: min(100vw, 430px);
   z-index: 90;
-  background-color: #ffffff;
-  border-top-left-radius: 2rem;
-  border-top-right-radius: 2rem;
+  background-color: #f9f8f6;
+  border-top: 1px solid #efe7dc;
+  border-top-left-radius: 2.1rem;
+  border-top-right-radius: 2.1rem;
   box-shadow:
-    0 -10px 25px -5px rgba(0, 0, 0, 0.1),
-    0 -8px 10px -6px rgba(0, 0, 0, 0.1);
+    0 -1.1rem 2.6rem rgba(72, 56, 38, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.68);
   display: flex;
   flex-direction: column;
   max-height: 90vh;
@@ -620,7 +621,7 @@ const handleSave = () => {
 .handle {
   width: 3rem;
   height: 0.375rem;
-  background-color: var(--color-surface-container-highest);
+  background-color: #d8cec1;
   border-radius: 9999px;
 }
 
@@ -629,51 +630,66 @@ const handleSave = () => {
    ========================================== */
 .sheet-content {
   flex: 1; /* 남은 공간을 채움 */
-  padding: 0 1.5rem 7rem 1.5rem;
   overflow-y: auto;
-  padding: 0 1.5rem 1.5rem 1.5rem;
+  padding: 0 1.2rem 1.5rem;
 }
 
 .sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 1rem;
-  text-align: center;
+  text-align: left;
   position: relative;
 }
 
 .sheet-title {
-  font-size: 1.125rem;
-  font-weight: 700;
-  color: var(--color-secondary);
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: #1d1814;
 }
 
 .close-button {
-  position: absolute;
-  right: 0;
-  top: 0;
-  padding: 0.25rem;
-  color: var(--color-on-surface-variant);
-  border-radius: 9999px;
-  transition: background-color 0.2s;
+  width: 2.55rem;
+  height: 2.55rem;
+  padding: 0;
+  color: #5b4939;
+  background: #ffffff;
+  border: 1px solid #efe7dc;
+  border-radius: 0.85rem;
+  box-shadow: 0 0.45rem 1rem rgba(72, 56, 38, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.62);
+  transition:
+    transform 0.14s ease,
+    background-color 0.14s ease;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .close-button:hover {
-  background-color: var(--color-surface-container);
+  background-color: #fff4dd;
+}
+
+.close-button:active {
+  transform: scale(0.96);
 }
 
 .selected-date-chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin: 0 auto 1.5rem;
-  padding: 0.5rem 0.875rem;
-  background-color: rgba(255, 188, 80, 0.16);
-  color: var(--color-secondary);
+  margin: 0 0 1.25rem;
+  padding: 0.5rem 0.9rem;
+  background-color: #fff4dd;
+  border: 1px solid #f3dfbd;
+  color: #5b4939;
   border-radius: 9999px;
   font-size: 0.8125rem;
   font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 /* ==========================================
@@ -681,15 +697,22 @@ const handleSave = () => {
    ========================================== */
 .amount-section {
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1.2rem;
+  padding: 1.35rem 1.25rem;
+  border: 1px solid #e7e3de;
+  border-radius: 1.35rem;
+  background: #f1f0ed;
+  box-shadow: 0 0.75rem 1.6rem rgba(72, 56, 38, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.66);
 }
 
 .amount-label {
   display: block;
   font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-on-surface-variant);
+  font-weight: 800;
+  color: #8a8179;
   margin-bottom: 0.5rem;
+  letter-spacing: -0.02em;
 }
 
 .amount-input-wrapper {
@@ -702,7 +725,7 @@ const handleSave = () => {
 .amount-input {
   font-size: 2.25rem;
   font-weight: 800;
-  color: var(--color-secondary);
+  color: #1d1814;
   background: transparent;
   border: none;
   text-align: center;
@@ -714,14 +737,14 @@ const handleSave = () => {
 .amount-currency {
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--color-on-surface-variant);
+  color: #8a8179;
 }
 
 .amount-underline {
   margin-top: 1rem;
   width: 100%;
-  height: 0.25rem;
-  background-color: rgba(255, 188, 80, 0.2);
+  height: 0.2rem;
+  background-color: rgba(75, 68, 51, 0.16);
   border-radius: 9999px;
 }
 
@@ -749,14 +772,26 @@ const handleSave = () => {
   justify-content: space-between;
   min-width: 0;
   padding: 1rem;
-  background-color: var(--color-surface-container-low);
-  border-radius: 1rem;
-  transition: transform 0.1s;
+  background-color: #ffffff;
+  border: 1px solid #efe7dc;
+  border-radius: 1.1rem;
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  transition:
+    transform 0.14s ease,
+    background-color 0.14s ease,
+    border-color 0.14s ease;
 }
 
 .field-button:hover,
 .field-row:hover {
-  background-color: var(--color-surface-container-low);
+  background-color: #fffdf8;
+  border-color: #f3dfbd;
+}
+
+.field-button:active,
+.field-row:active {
+  transform: scale(0.99);
 }
 
 .field-row--picker {
@@ -776,16 +811,16 @@ const handleSave = () => {
 }
 
 .field-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
-  background-color: #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: #fff4dd;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-secondary);
   transition: transform 0.2s;
+  flex-shrink: 0;
 }
 
 .field-button:hover .field-icon,
@@ -795,7 +830,7 @@ const handleSave = () => {
 
 .field-label {
   font-weight: 700;
-  color: var(--color-secondary);
+  color: #1d1814;
 }
 
 .field-right {
@@ -805,12 +840,13 @@ const handleSave = () => {
   align-items: center;
   justify-content: flex-end;
   gap: 0.5rem;
-  color: var(--color-on-surface-variant);
+  color: #8a8179;
 }
 
 .field-value {
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: 700;
+  color: #5b4939;
 }
 
 .chevron {
@@ -827,11 +863,9 @@ const handleSave = () => {
   right: 0;
   margin-top: 0.5rem;
   background-color: #ffffff;
-  border-radius: 1rem;
-  box-shadow:
-    0 10px 25px -5px rgba(0, 0, 0, 0.1),
-    0 8px 10px -6px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--color-surface-container-highest);
+  border-radius: 1.1rem;
+  box-shadow: 0 1rem 2rem rgba(72, 56, 38, 0.1);
+  border: 1px solid #efe7dc;
   z-index: 20;
   overflow: hidden;
 }
@@ -850,31 +884,34 @@ const handleSave = () => {
   padding: 1rem 1.5rem;
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--color-secondary);
+  color: #1d1814;
   transition: background-color 0.2s;
   text-align: left;
 }
 
 .dropdown-item:hover {
-  background-color: rgba(255, 188, 80, 0.1);
+  background-color: #fff4dd;
 }
 
 .dropdown-icon {
-  color: var(--color-on-surface-variant);
-  background-color: var(--color-surface-container-low);
-  padding: 0.5rem;
-  border-radius: 0.5rem;
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: #fff4dd;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .category-image-mask {
-  width: 1.9rem;
-  height: 1.9rem;
+  width: 100%;
+  height: 100%;
   border-radius: 9999px;
   overflow: hidden;
-  background: rgba(255, 188, 80, 0.16);
+  background: #fff4dd;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -882,23 +919,22 @@ const handleSave = () => {
 }
 
 .category-image-mask--sm {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 100%;
+  height: 100%;
 }
 
 .category-image {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transform: scale(1.12);
 }
 
 .action-image-mask {
-  width: 1.9rem;
-  height: 1.9rem;
+  width: 100%;
+  height: 100%;
   border-radius: 9999px;
   overflow: hidden;
-  background: rgba(255, 188, 80, 0.16);
+  background: #fff4dd;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -909,16 +945,14 @@ const handleSave = () => {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transform: scale(1.08);
 }
 
 .picker-panel {
-  border: 1px solid rgba(209, 198, 184, 0.7);
+  border: 1px solid #efe7dc;
   background: #fffdf8;
-  border-radius: 1rem;
-  box-shadow:
-    0 14px 28px -18px rgba(42, 34, 24, 0.28),
-    0 8px 12px -10px rgba(42, 34, 24, 0.16);
+  border-radius: 1.1rem;
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
   padding: 0.9rem;
 }
 
@@ -932,7 +966,7 @@ const handleSave = () => {
 
 .picker-panel-title {
   margin: 0;
-  color: var(--color-secondary);
+  color: #1d1814;
   font-size: 0.95rem;
   font-weight: 800;
   letter-spacing: -0.02em;
@@ -945,15 +979,15 @@ const handleSave = () => {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-secondary);
-  background: rgba(255, 188, 80, 0.14);
+  color: #5b4939;
+  background: #fff4dd;
   transition:
     transform 0.15s ease,
     background-color 0.15s ease;
 }
 
 .picker-nav-button:hover {
-  background: rgba(255, 188, 80, 0.22);
+  background: #ffedc7;
 }
 
 .picker-nav-button:active {
@@ -971,7 +1005,7 @@ const handleSave = () => {
   text-align: center;
   font-size: 0.68rem;
   font-weight: 700;
-  color: var(--color-on-surface-variant);
+  color: #b7b0aa;
 }
 
 .calendar-grid {
@@ -982,10 +1016,10 @@ const handleSave = () => {
 
 .calendar-day-button {
   aspect-ratio: 1;
-  border-radius: 0.9rem;
+  border-radius: 0.85rem;
   font-size: 0.86rem;
   font-weight: 700;
-  color: var(--color-secondary);
+  color: #30241a;
   background: transparent;
   transition:
     transform 0.15s ease,
@@ -994,16 +1028,18 @@ const handleSave = () => {
 }
 
 .calendar-day-button.is-muted {
-  color: rgba(112, 99, 84, 0.42);
+  color: #ded8d1;
 }
 
 .calendar-day-button.is-today {
-  box-shadow: inset 0 0 0 1px rgba(255, 188, 80, 0.5);
+  background: rgba(255, 191, 56, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
 }
 
 .calendar-day-button.is-selected {
-  background: var(--color-primary);
-  color: var(--color-secondary);
+  background: #ffbf38;
+  color: #30241a;
+  box-shadow: 0 0.45rem 0.9rem rgba(255, 191, 56, 0.28);
 }
 
 .calendar-day-button:active {
@@ -1016,12 +1052,13 @@ const handleSave = () => {
   justify-content: flex-end;
   max-width: min(100%, 9.5rem);
   min-width: 0;
-  background-color: #ffffff;
+  background-color: #fff4dd;
   padding: 0.5rem 1rem;
   border-radius: 0.75rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: 700;
+  color: #5b4939;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1046,14 +1083,14 @@ const handleSave = () => {
   margin: 0;
   font-size: 0.72rem;
   font-weight: 700;
-  color: var(--color-on-surface-variant);
+  color: #8a8179;
 }
 
 .time-wheel-value {
   margin: 0.25rem 0 0;
   font-size: 1.05rem;
   font-weight: 800;
-  color: var(--color-secondary);
+  color: #1d1814;
   letter-spacing: -0.03em;
   white-space: nowrap;
   overflow: hidden;
@@ -1065,8 +1102,8 @@ const handleSave = () => {
   height: 2rem;
   padding: 0 0.85rem;
   border-radius: 9999px;
-  background: rgba(255, 188, 80, 0.18);
-  color: var(--color-secondary);
+  background: #fff4dd;
+  color: #5b4939;
   font-size: 0.78rem;
   font-weight: 800;
   transition:
@@ -1089,7 +1126,7 @@ const handleSave = () => {
 .time-wheel-column {
   position: relative;
   border-radius: 1rem;
-  background: rgba(255, 188, 80, 0.08);
+  background: #fff4dd;
   padding: 0.65rem 0.55rem;
   min-width: 0;
   overflow: hidden;
@@ -1109,7 +1146,7 @@ const handleSave = () => {
   transform: translateY(-50%);
   border-radius: 0.9rem;
   background: rgba(255, 255, 255, 0.78);
-  border: 1px solid rgba(209, 198, 184, 0.55);
+  border: 1px solid #efe7dc;
   pointer-events: none;
 }
 
@@ -1119,7 +1156,7 @@ const handleSave = () => {
   padding-left: 0.35rem;
   font-size: 0.72rem;
   font-weight: 700;
-  color: var(--color-on-surface-variant);
+  color: #8a8179;
 }
 
 .time-wheel-list {
@@ -1162,7 +1199,7 @@ const handleSave = () => {
 }
 
 .wheel-option.is-selected {
-  color: var(--color-secondary);
+  color: #1d1814;
   font-size: 1.08rem;
   font-weight: 800;
 }
@@ -1182,7 +1219,12 @@ const handleSave = () => {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  padding-top: 0.5rem;
+  padding: 1rem;
+  border: 1px solid #efe7dc;
+  border-radius: 1.1rem;
+  background: #ffffff;
+  box-shadow: 0 0.8rem 1.8rem rgba(72, 56, 38, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .memo-header {
@@ -1193,28 +1235,28 @@ const handleSave = () => {
 }
 
 .memo-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
-  background-color: #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: #fff4dd;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-secondary);
+  flex-shrink: 0;
 }
 
 .memo-input {
   width: 100%;
-  background-color: var(--color-surface-container-low);
-  border: none;
+  background-color: #fffdf8;
+  border: 1px solid #efe7dc;
   border-radius: 1rem;
   padding: 1.25rem;
   font-size: 0.875rem;
   font-weight: 500;
   min-height: 6.25rem;
   resize: none;
-  color: var(--color-secondary);
+  color: #1d1814;
   transition: all 0.2s;
   outline: none;
 }
@@ -1224,21 +1266,21 @@ const handleSave = () => {
 }
 
 .memo-input::placeholder {
-  color: rgba(74, 68, 63, 0.3);
+  color: #aba29b;
 }
 
 .notice-box {
-  margin-top: 2rem;
+  margin-top: 1.2rem;
   padding: 1rem;
-  background-color: rgba(255, 188, 80, 0.1);
-  border-radius: 0.75rem;
-  border: 1px solid rgba(255, 188, 80, 0.2);
+  background-color: #fff4dd;
+  border-radius: 1rem;
+  border: 1px solid #f3dfbd;
   display: flex;
   gap: 0.75rem;
 }
 
 .notice-icon {
-  color: var(--color-secondary);
+  color: #5b4939;
   flex-shrink: 0;
   display: flex;
   align-items: flex-start;
@@ -1246,12 +1288,13 @@ const handleSave = () => {
 
 .notice-text {
   font-size: 0.8125rem;
-  color: var(--color-on-surface-variant);
+  color: #7b736d;
   line-height: 1.6;
+  margin: 0;
 }
 
 .notice-highlight {
-  color: var(--color-secondary);
+  color: #5b4939;
   font-weight: 700;
 }
 
@@ -1263,8 +1306,9 @@ const handleSave = () => {
   bottom: 0; */
   left: 0;
   right: 0;
-  padding: 1.5rem;
-  background-color: rgba(255, 255, 255, 0.9);
+  padding: 1rem 1.2rem 1.35rem;
+  background-color: rgba(249, 248, 246, 0.92);
+  border-top: 1px solid #efe7dc;
   backdrop-filter: blur(12px);
 }
 
@@ -1279,15 +1323,20 @@ const handleSave = () => {
 .save-button {
   width: 100%;
   height: 3.5rem;
-  background-color: var(--color-primary);
-  color: var(--color-secondary);
-  border-radius: 0.5rem;
+  background-color: #5b4939;
+  color: #ffc341;
+  border-radius: 1.1rem;
   font-weight: 800;
   font-size: 1.125rem;
-  box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.1),
-    0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  transition: transform 0.1s;
+  box-shadow: 0 0.9rem 1.8rem rgba(45, 35, 24, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transition:
+    transform 0.14s ease,
+    background-color 0.14s ease;
+}
+
+.save-button:hover {
+  background-color: #524131;
 }
 
 .save-button:active {

--- a/src/components/HoneyPot.vue
+++ b/src/components/HoneyPot.vue
@@ -15,8 +15,8 @@ const props = withDefaults(
   },
 )
 
-const animatedDisplayValue = ref(props.displayValue)
-const animatedFillPercent = ref(props.fillPercentage)
+const animatedDisplayValue = ref(0)
+const animatedFillPercent = ref(0)
 
 // 중앙 숫자 애니메이션
 watch(

--- a/src/components/HoneyPot.vue
+++ b/src/components/HoneyPot.vue
@@ -145,7 +145,7 @@ const fillHeight = computed(() => `${Math.min(Math.max(animatedFillPercent.value
       <!-- Guideline Exclamation Icon (Outside overflow-hidden to overlap border) -->
       <div class="absolute top-2 left-0 w-full h-full pointer-events-none z-30">
         <div
-          class="absolute left-[-32px] flex items-center justify-center w-7 h-7 bg-[#ff3b30] text-white font-black text-sm rounded-full border-[2.5px] border-white shadow-sm transition-all duration-500"
+          class="absolute left-[-32px] flex items-center justify-center w-7 h-7 bg-[#ff3b30] text-white font-black text-sm rounded-full border-[2.5px] border-white shadow-sm"
           :style="{ bottom: `calc(${guidelinePercentage}% - 14px)` }"
         >
           !
@@ -182,7 +182,7 @@ const fillHeight = computed(() => `${Math.min(Math.max(animatedFillPercent.value
 
         <!-- Guideline Dashed Line (z-5: Above honey, below text) -->
         <div
-          class="absolute left-0 w-full border-t-[3px] border-dashed border-[#ff3b30] transition-all duration-500 z-[5]"
+          class="absolute left-0 w-full border-t-[3px] border-dashed border-[#ff3b30] z-[5]"
           :style="{ bottom: `${guidelinePercentage}%` }"
         ></div>
 

--- a/src/pages/Setup/ExpenseGoalSetup.vue
+++ b/src/pages/Setup/ExpenseGoalSetup.vue
@@ -33,6 +33,13 @@ const isStockListOpen = ref(false)
 const showErrors = ref(false)
 
 const popularStocks = computed(() => budgetStore.stockOptions)
+const monthlyBudgetAmount = computed(() => Number(lastMonthExpense.value) || 0)
+const targetQuantityAmount = computed(() => Number(targetQuantity.value) || 0)
+const isMonthlyBudgetValid = computed(() => monthlyBudgetAmount.value > 0)
+const isTargetQuantityValid = computed(() => targetQuantityAmount.value > 0)
+const isGoalSetupValid = computed(
+  () => isMonthlyBudgetValid.value && Boolean(selectedStock.value) && isTargetQuantityValid.value,
+)
 
 // Get User ID from session
 const getUserId = () => {
@@ -128,15 +135,15 @@ const setTargetStock = (stock) => {
 const handleStartSaving = async () => {
   showErrors.value = true
 
-  if (!lastMonthExpense.value || !selectedStock.value || !targetQuantity.value) {
+  if (!isGoalSetupValid.value) {
     return
   }
 
   try {
     const member = await budgetStore.updateGoalSetup({
-      monthlyBudget: Number(lastMonthExpense.value),
+      monthlyBudget: monthlyBudgetAmount.value,
       targetStockId: selectedStock.value.id,
-      targetQuantity: Number(targetQuantity.value),
+      targetQuantity: targetQuantityAmount.value,
     })
 
     syncGoalSetupSession(member)
@@ -200,12 +207,12 @@ const handleStartSaving = async () => {
           </div>
 
           <Motion
-            v-if="showErrors && !lastMonthExpense"
+            v-if="showErrors && !isMonthlyBudgetValid"
             :initial="{ opacity: 0, y: -10 }"
             :animate="{ opacity: 1, y: 0 }"
             class="text-red-500 text-sm font-bold px-1"
           >
-            생활비를 입력하세요.
+            생활비는 1원 이상 입력하세요.
           </Motion>
 
           <div class="flex items-start gap-2 px-1">
@@ -338,12 +345,12 @@ const handleStartSaving = async () => {
           </div>
 
           <Motion
-            v-if="showErrors && !targetQuantity"
+            v-if="showErrors && !isTargetQuantityValid"
             :initial="{ opacity: 0, y: -10 }"
             :animate="{ opacity: 1, y: 0 }"
             class="text-red-500 text-sm font-bold px-1"
           >
-            목표 수량을 입력하세요.
+            목표 수량은 0보다 크게 입력하세요.
           </Motion>
 
           <div class="flex items-start gap-2 px-1">

--- a/src/pages/Setup/ExpenseGoalSetup.vue
+++ b/src/pages/Setup/ExpenseGoalSetup.vue
@@ -48,6 +48,25 @@ const getUserId = () => {
   return null
 }
 
+const syncGoalSetupSession = (member) => {
+  try {
+    const session = JSON.parse(localStorage.getItem('userSession') || 'null')
+    if (!session || String(session.id) !== String(member?.id)) return
+
+    localStorage.setItem(
+      'userSession',
+      JSON.stringify({
+        ...session,
+        monthlyBudget: member.monthlyBudget,
+        targetStockId: member.targetStockId,
+        targetQuantity: member.targetQuantity,
+      }),
+    )
+  } catch (error) {
+    console.error('Failed to sync user session goal setup:', error)
+  }
+}
+
 const userId = getUserId()
 
 onMounted(async () => {
@@ -114,11 +133,13 @@ const handleStartSaving = async () => {
   }
 
   try {
-    await budgetStore.updateGoalSetup({
+    const member = await budgetStore.updateGoalSetup({
       monthlyBudget: Number(lastMonthExpense.value),
       targetStockId: selectedStock.value.id,
       targetQuantity: Number(targetQuantity.value),
     })
+
+    syncGoalSetupSession(member)
 
     alert('설정이 저장되었습니다!')
     router.push('/home')

--- a/src/pages/Setup/ExpenseGoalSetup.vue
+++ b/src/pages/Setup/ExpenseGoalSetup.vue
@@ -442,17 +442,20 @@ const handleStartSaving = async () => {
 
 <style scoped>
 .custom-scrollbar::-webkit-scrollbar {
-  width: 6px;
+  width: var(--scrollbar-size, 8px);
 }
 .custom-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track, transparent);
+  border-radius: var(--scrollbar-radius, 999px);
 }
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background: #d6d2ce;
-  border-radius: 10px;
+  background-color: var(--scrollbar-thumb, #d8c8ad);
+  border: var(--scrollbar-border, 2px solid transparent);
+  border-radius: var(--scrollbar-radius, 999px);
+  background-clip: padding-box;
 }
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: #6d6864;
+  background-color: var(--scrollbar-thumb-hover, #c5ad86);
 }
 
 .start-button-area {

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -759,18 +759,18 @@ async function handleExpenseSave(payload) {
 .history-icon {
   display: grid;
   place-items: center;
-  width: 4.1rem;
-  height: 4.1rem;
-  border-radius: 0.95rem;
-  background: #f5ead8;
-  box-shadow: var(--shadow-soft);
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
 .history-icon-image {
-  width: 2.35rem;
-  height: 2.35rem;
+  display: block;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  border-radius: 999px;
 }
 
 .history-copy {
@@ -937,8 +937,8 @@ async function handleExpenseSave(payload) {
   }
 
   .history-icon {
-    width: 3.5rem;
-    height: 3.5rem;
+    width: 3rem;
+    height: 3rem;
   }
 
   .floating-action {

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -16,6 +16,7 @@ const HISTORY_INCREMENT = 10
 
 const currentMonth = ref(dayjs().startOf('month'))
 const selectedDate = ref(dayjs())
+const expenseInputDate = ref(dayjs())
 const isCalendarDetailOpen = ref(false)
 const isExpenseInputOpen = ref(false)
 const reopenCalendarDetail = ref(false)
@@ -45,12 +46,6 @@ const getSessionMemberId = () => {
 onMounted(async () => {
   try {
     await budgetStore.initializeBudgetState(getSessionMemberId())
-    const latestExpenseDate = budgetStore.recentExpenses[0]?.date
-
-    if (latestExpenseDate) {
-      selectedDate.value = dayjs(latestExpenseDate)
-      currentMonth.value = selectedDate.value.startOf('month')
-    }
   } catch (error) {
     console.error('Failed to initialize budget store:', error)
   }
@@ -59,6 +54,7 @@ onMounted(async () => {
 const visibleHistoryCount = ref(INITIAL_HISTORY_COUNT)
 const currentMonthKey = computed(() => currentMonth.value.format('YYYY-MM'))
 const selectedDateKey = computed(() => selectedDate.value.format('YYYY-MM-DD'))
+const expenseInputDateKey = computed(() => expenseInputDate.value.format('YYYY-MM-DD'))
 const todayDateKey = computed(() => dayjs().format('YYYY-MM-DD'))
 const expenseDateSet = computed(() => new Set(expenses.value.map((expense) => expense.date)))
 const selectedDayExpenses = computed(() => budgetStore.getExpensesByDate(selectedDateKey.value))
@@ -190,11 +186,13 @@ function closeCalendarDetail() {
 
 function showExpenseInput() {
   reopenCalendarDetail.value = false
+  expenseInputDate.value = dayjs()
   isExpenseInputOpen.value = true
 }
 
 function openExpenseInputFromCalendar() {
   reopenCalendarDetail.value = true
+  expenseInputDate.value = selectedDate.value
   isCalendarDetailOpen.value = false
   isExpenseInputOpen.value = true
 }
@@ -351,7 +349,7 @@ async function handleExpenseSave(payload) {
 
         <ExpenseInput
           :is-open="isExpenseInputOpen"
-          :selected-date="selectedDateKey"
+          :selected-date="expenseInputDateKey"
           @close="closeExpenseInput"
           @save="handleExpenseSave"
         />

--- a/src/pages/reportPage/ReportPage.vue
+++ b/src/pages/reportPage/ReportPage.vue
@@ -57,6 +57,20 @@ function getSessionUser() {
   }
 }
 
+function getReportMonthTime(report) {
+  const targetMonth = report?.targetMonth
+  if (typeof targetMonth !== 'string') return 0
+
+  const monthDate = new Date(`${targetMonth}-01T00:00:00`)
+  return Number.isNaN(monthDate.getTime()) ? 0 : monthDate.getTime()
+}
+
+function selectLatestReport(reports) {
+  if (!Array.isArray(reports) || reports.length === 0) return null
+
+  return [...reports].sort((a, b) => getReportMonthTime(b) - getReportMonthTime(a))[0]
+}
+
 async function appendStockTicker(report) {
   if (!report?.stockId) return report
 
@@ -90,7 +104,7 @@ onMounted(async () => {
       params: { memberId: currentUser.id },
     })
 
-    const report = response.data?.[0] ?? null
+    const report = selectLatestReport(response.data)
     reportData.value = await appendStockTicker(report)
     emptyMessage.value = `${currentUser.name ?? '사용자'}님의 리포트가 아직 없습니다.`
   } catch (error) {

--- a/src/pages/reportPage/ReportPage.vue
+++ b/src/pages/reportPage/ReportPage.vue
@@ -42,6 +42,7 @@ import axios from 'axios'
 
 // Vite proxy는 '/api' 경로만 프록시하므로 반드시 leading slash가 필요합니다.
 const BASEURI = '/api/reports'
+const STOCK_BASEURI = '/api/stocks'
 
 const reportData = ref(null)
 const isLoading = ref(true)
@@ -53,6 +54,24 @@ function getSessionUser() {
     return JSON.parse(localStorage.getItem('userSession') || 'null')
   } catch {
     return null
+  }
+}
+
+async function appendStockTicker(report) {
+  if (!report?.stockId) return report
+
+  try {
+    const response = await axios.get(`${STOCK_BASEURI}/${report.stockId}`)
+
+    return {
+      ...report,
+      stockTicker: response.data?.ticker ?? report.stockTicker ?? report.stockName,
+    }
+  } catch {
+    return {
+      ...report,
+      stockTicker: report.stockTicker ?? report.stockName,
+    }
   }
 }
 
@@ -71,7 +90,8 @@ onMounted(async () => {
       params: { memberId: currentUser.id },
     })
 
-    reportData.value = response.data?.[0] ?? null
+    const report = response.data?.[0] ?? null
+    reportData.value = await appendStockTicker(report)
     emptyMessage.value = `${currentUser.name ?? '사용자'}님의 리포트가 아직 없습니다.`
   } catch (error) {
     errorMessage.value = 'json-server 상태를 확인한 뒤 다시 시도해주세요.'

--- a/src/pages/reportPage/components/HeroReportCard.vue
+++ b/src/pages/reportPage/components/HeroReportCard.vue
@@ -25,7 +25,7 @@
             <div class="text-wrapper-4">아껴서</div>
           </div>
           <div class="heading-2">
-            <div class="text-wrapper-6">+{{ report.stockName }} {{ report.securedQuantity }}</div>
+            <div class="text-wrapper-6">+{{ stockLabel }} {{ report.securedQuantity }}</div>
             <div class="text-wrapper-7">주 확보</div>
           </div>
         </div>
@@ -36,7 +36,7 @@
                 <span class="img" aria-hidden="true">🎯</span>
               </div>
               <div class="container-8">
-                <div class="text-wrapper-8">{{ report.stockName }} {{ report.targetQuantity }}주 채우기 목표</div>
+                <div class="text-wrapper-8">{{ stockLabel }} {{ report.targetQuantity }}주 채우기 목표</div>
               </div>
             </div>
             <div class="container-7"><div class="text-wrapper-9">{{ report.progressRate }}%</div></div>
@@ -68,9 +68,10 @@ const isGoalAchieved = computed(() => {
   return props.report.securedQuantity >= props.report.targetQuantity || props.report.progressRate >= 100
 })
 
+const stockLabel = computed(() => props.report?.stockTicker ?? props.report?.stockName ?? '주식')
 const goalTitleLine1 = computed(() => '절약 목표를')
-const goalTitleLine2 = computed(() => (isGoalAchieved.value ? '달성했어요! 👏' : '미달성했어요 😢'))
-const goalStatusLabel = computed(() => (isGoalAchieved.value ? 'ACHIEVED' : 'IN PROGRESS'))
+const goalTitleLine2 = computed(() => (isGoalAchieved.value ? '달성했어요!👏' : '미달성했어요😢'))
+const goalStatusLabel = computed(() => (isGoalAchieved.value ? 'ACHIEVED' : 'FAILED'))
 
 onMounted(() => {
   setTimeout(() => {

--- a/src/pages/reportPage/components/OppurtunityCost.vue
+++ b/src/pages/reportPage/components/OppurtunityCost.vue
@@ -21,35 +21,40 @@
       지출했던 항목들을 주식으로 환산하면 이만큼입니다.
     </p>
 
-    <ul class="op-cost__list" v-if="report">
-      <li
-        v-for="category in report.topCategories"
-        :key="category.categoryId"
-        class="op-cost__card"
-        :class="category.rank === 1 ? 'op-cost__card--tall' : 'op-cost__card--short'"
-      >
-        <div class="op-cost__left">
-          <div class="op-cost__icon-wrap">
-            <img
-              :src="category.categoryImageUrl"
-              :alt="category.categoryName"
-              class="op-cost__category-icon"
-            />
+    <template v-if="report">
+      <ul class="op-cost__list">
+        <li
+          v-for="category in report.topCategories"
+          :key="category.categoryId"
+          class="op-cost__card"
+          :class="category.rank === 1 ? 'op-cost__card--tall' : 'op-cost__card--short'"
+        >
+          <div class="op-cost__left">
+            <div class="op-cost__icon-wrap">
+              <img
+                :src="category.categoryImageUrl"
+                :alt="category.categoryName"
+                class="op-cost__category-icon"
+              />
+            </div>
+
+            <div class="op-cost__text">
+              <span class="op-cost__name">{{ category.categoryName }}</span>
+              <span class="op-cost__sub">지난달 {{ category.amount.toLocaleString() }}원 지출</span>
+            </div>
           </div>
 
-          <div class="op-cost__text">
-            <span class="op-cost__name">{{ category.categoryName }}</span>
-            <span class="op-cost__sub">지난달 {{ category.amount.toLocaleString() }}원 지출</span>
+          <div class="op-cost__right" :class="{ 'op-cost__right--stack': category.rank === 1 }">
+            <span class="op-cost__shares">+{{ category.additionalQuantity }}주</span>
+
+            <span v-if="category.rank === 1" class="op-cost__badge">절약 집중 항목</span>
           </div>
-        </div>
-
-        <div class="op-cost__right" :class="{ 'op-cost__right--stack': category.rank === 1 }">
-          <span class="op-cost__shares">+{{ category.additionalQuantity }}주</span>
-
-          <span v-if="category.rank === 1" class="op-cost__badge">절약 집중 항목</span>
-        </div>
-      </li>
-    </ul>
+        </li>
+      </ul>
+      <p v-if="report.summaryComment" class="op-cost__summary">
+        {{ report.summaryComment }}
+      </p>
+    </template>
     <div v-else>데이터 로딩 중...</div>
   </section>
 </template>
@@ -249,5 +254,20 @@ defineProps({
   line-height: 15px;
   color: #ea580c;
   white-space: nowrap;
+}
+
+.op-cost__summary {
+  margin: 0;
+  padding: 15px 16px;
+  border-radius: 18px;
+  background-color: #fff7ed;
+  border: 1px solid #ffbc5033;
+  font-family: 'Pretendard Variable', Pretendard, Helvetica, system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.65;
+  letter-spacing: -0.2px;
+  color: #7a4f1b;
+  word-break: keep-all;
 }
 </style>

--- a/src/pages/signupPage/SignupPage.vue
+++ b/src/pages/signupPage/SignupPage.vue
@@ -214,9 +214,21 @@ const registerUser = async () => {
     });
 
     if (response.ok) {
+      const createdUserData = await response.json();
+      const sessionData = {
+        userId: createdUserData.userId,
+        name: createdUserData.name,
+        monthlyBudget: createdUserData.monthlyBudget,
+        targetStockId: createdUserData.targetStockId,
+        targetQuantity: createdUserData.targetQuantity,
+        ageBand: createdUserData.ageBand,
+        id: createdUserData.id,
+      };
+
+      localStorage.setItem('userSession', JSON.stringify(sessionData));
+      router.push('/setup');
 
       // 성공 시 폼 초기화
-      router.push('/setup');
       userId.value = '';
       name.value = '';
       birthdate.value = '';

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,14 +1,13 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-/*
 function hasSession() {
   try {
-    return Boolean(JSON.parse(localStorage.getItem('userSession') || 'null'))
+    return Boolean(JSON.parse(localStorage.getItem('userSession') || 'null')?.id)
   } catch {
     return false
   }
 }
-*/
+
 import Setup from '@/pages/Setup/ExpenseGoalSetup.vue'
 
 const router = createRouter({
@@ -16,9 +15,7 @@ const router = createRouter({
   routes: [
     {
       path: '/',
-      // Dev only: open the home page while auth flow is still in progress.
-      redirect: '/home',
-      // redirect: () => (hasSession() ? '/home' : '/login'),
+      redirect: () => (hasSession() ? '/home' : '/login'),
     },
 
     {
@@ -52,27 +49,27 @@ const router = createRouter({
       path: '/setup',
       name: 'setup',
       component: Setup,
+      meta: { requiresAuth: true },
     },
     {
       path: '/report',
       name: 'report',
       component: () => import('@/pages/reportPage/ReportPage.vue'),
       meta: { requiresAuth: true, showTopBar: true, showBottomNav: true },
-    }
+    },
   ],
 })
 
-// Dev only: temporarily disable route guards until auth flow is finalized.
-// router.beforeEach((to) => {
-//   const isAuthenticated = hasSession()
-//
-//   if (to.meta.requiresAuth && !isAuthenticated) {
-//     return '/login'
-//   }
-//
-//   if (to.meta.guestOnly && isAuthenticated) {
-//     return '/home'
-//   }
-// })
+router.beforeEach((to) => {
+  const isAuthenticated = hasSession()
+
+  if (to.meta.requiresAuth && !isAuthenticated) {
+    return '/login'
+  }
+
+  if (to.meta.guestOnly && isAuthenticated) {
+    return '/home'
+  }
+})
 
 export default router

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -51,6 +51,7 @@ export const useBudgetStore = defineStore('budget', {
     categories: [],
     expenses: [],
     isLoading: false,
+    loadingPromise: null,
     error: null,
     initialized: false,
   }),
@@ -264,8 +265,31 @@ export const useBudgetStore = defineStore('budget', {
     },
 
     async initializeBudgetState(memberId = null) {
-      if (this.isLoading) return
+      const requestedMemberId = memberId ?? this.memberId
 
+      if (this.loadingPromise) {
+        await this.loadingPromise
+
+        if (
+          requestedMemberId === null ||
+          requestedMemberId === undefined ||
+          requestedMemberId === '' ||
+          String(this.memberId) === String(requestedMemberId)
+        ) {
+          return
+        }
+      }
+
+      this.loadingPromise = this.loadBudgetState(requestedMemberId)
+
+      try {
+        await this.loadingPromise
+      } finally {
+        this.loadingPromise = null
+      }
+    },
+
+    async loadBudgetState(memberId = null) {
       this.isLoading = true
       this.error = null
 

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -198,6 +198,7 @@ export const useBudgetStore = defineStore('budget', {
         return {
           securedQuantity: stockQuantity,
           stockName: this.targetStockName || '주식',
+          stockTicker: this.targetStockTicker || this.targetStockName || '주식',
           savedAmount: Math.abs(diffFromAverage),
           isSaved: diffFromAverage >= 0,
           progressRate,

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -31,6 +31,15 @@ function toTimeKey(spentAt) {
   return typeof spentAt === 'string' && spentAt.includes('T') ? spentAt.slice(11, 16) : ''
 }
 
+function toMonthKey(date = new Date()) {
+  const nextDate = date instanceof Date ? date : new Date(date)
+  if (Number.isNaN(nextDate.getTime())) return ''
+
+  const year = nextDate.getFullYear()
+  const month = String(nextDate.getMonth() + 1).padStart(2, '0')
+  return `${year}-${month}`
+}
+
 export const useBudgetStore = defineStore('budget', {
   state: () => ({
     memberId: null,
@@ -88,10 +97,12 @@ export const useBudgetStore = defineStore('budget', {
       }))
     },
 
+    currentMonthKey: () => toMonthKey(),
+
     totalExpense: (state) => state.expenses.reduce((sum, expense) => sum + expense.amount, 0),
 
     monthlyExpenseTotal() {
-      return this.totalExpense
+      return this.getMonthlyExpenseTotal(this.currentMonthKey)
     },
 
     expensesByDate(state) {
@@ -133,7 +144,7 @@ export const useBudgetStore = defineStore('budget', {
     },
 
     remainingBudget(state) {
-      return state.budget - this.totalExpense
+      return state.budget - this.monthlyExpenseTotal
     },
 
     fillPercentage(state) {
@@ -218,17 +229,17 @@ export const useBudgetStore = defineStore('budget', {
       this.targetQuantity = toNumber(member?.targetQuantity)
     },
 
-    resolveMember(members, requestedMemberId) {
-      if (requestedMemberId !== null && requestedMemberId !== undefined) {
+    resolveMember(members, requestedMemberId = this.memberId) {
+      if (
+        requestedMemberId !== null &&
+        requestedMemberId !== undefined &&
+        requestedMemberId !== ''
+      ) {
         const matched = members.find((member) => String(member.id) === String(requestedMemberId))
         if (matched) return matched
       }
 
-      return (
-        members.find((member) => toNumber(member.monthlyBudget) > 0 && member.targetStockId) ??
-        members[0] ??
-        null
-      )
+      return null
     },
 
     async loadReferenceData() {
@@ -261,8 +272,10 @@ export const useBudgetStore = defineStore('budget', {
         const members = await requestJson('/members')
         await this.loadReferenceData()
 
-        const member = this.resolveMember(members, memberId)
+        const member = this.resolveMember(members, memberId ?? this.memberId)
         if (!member) {
+          this.applyMember(null)
+          this.expenses = []
           this.initialized = true
           return
         }
@@ -283,6 +296,10 @@ export const useBudgetStore = defineStore('budget', {
         await this.initializeBudgetState()
       }
 
+      if (!this.memberId) {
+        throw new Error('Cannot update goal setup without a selected member')
+      }
+
       const payload = {
         monthlyBudget: toNumber(monthlyBudget),
         targetStockId,
@@ -301,6 +318,10 @@ export const useBudgetStore = defineStore('budget', {
     async addExpense(payload) {
       if (!this.memberId) {
         await this.initializeBudgetState()
+      }
+
+      if (!this.memberId) {
+        throw new Error('Cannot add expense without a selected member')
       }
 
       const category =


### PR DESCRIPTION
## 🧩 작업 내용

- 로그인 가드 복구 및 사용자 세션 기준 데이터 흐름을 정리했습니다.
- Pinia 예산/지출 상태가 로그인 사용자 기준으로 초기화되도록 보완했습니다.
- Pinia 초기화 중복 호출 시 동일 Promise를 기다리도록 수정해 지출 추가/목표 수정 race condition을 방지했습니다.
- 홈 진입 시 선택 날짜가 오늘로 초기화되도록 정리했습니다.
- 캘린더에서 날짜 선택 후 지출 추가 시 해당 날짜가 입력 화면으로 전달되도록 연결했습니다.
- 지출 추가 후 홈의 꿀통, 잔여 생활비, 최근 소비 내역, 일일 요약이 반응형으로 갱신되도록 유지했습니다.
- 목표설정 저장 시 Pinia 상태와 `userSession`이 함께 갱신되도록 보완했습니다.
- 목표설정에서 `0원`, `0주`가 저장되지 않도록 검증을 추가했습니다.
- 리포트 페이지는 사용자 기준 최신 `targetMonth` 리포트 스냅샷을 선택하도록 수정했습니다.
- 리포트 내 주식 표기를 긴 종목명 대신 티커 기준으로 정리했습니다.
- 리포트 실패 상태를 `FAILED`로 표시하고, `summaryComment`가 자연스럽게 노출되도록 개선했습니다.
- 강민지/진승환 페르소나용 지출 및 리포트 fixture를 보강했습니다.
- 홈 최근 소비 내역, 일일 요약, 지출 입력 화면의 아이콘/상태 표시를 정리했습니다.
- 꿀통 애니메이션은 0부터 차오르도록 적용하고, 목표 기준선은 고정되도록 유지했습니다.
- 전역 스크롤바 테마를 추가하고 기본값을 최소 표시형으로 설정했습니다.
- 상단바/하단바에는 스크롤바 테마 영향이 가지 않도록 적용 범위를 제한했습니다.

## ✅ 확인 사항

- 리포트 페이지는 지난달 스냅샷 데이터이므로 지출 추가 시 동적으로 변경되지 않도록 유지했습니다.
- 홈/목표설정/지출입력은 현재 로그인 사용자 기준으로 Pinia 상태를 공유합니다.
- 지출 입력 후 홈의 월 잔여 생활비, 꿀통, 최근 소비 내역, 날짜별 상세 내역이 갱신됩니다.
- 목표설정 변경 후 홈 기준선과 계산값이 갱신됩니다.

## 🧪 테스트

- `npm run build`
- `npm run validate:db`
