### PR TITLE
fix: 생활비 초과 지출 및 주식 목표 설정 거절

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:server": "json-server --watch db.json --port 3000",
     "build": "vite build",
     "preview": "vite preview",
+    "test:unit": "node --test src/utils/budgetValidation.test.js",
     "lint": "eslint . --fix",
     "format": "prettier --write src/",
     "validate:db": "node scripts/validate-db.mjs"

--- a/src/components/ExpenseInput.vue
+++ b/src/components/ExpenseInput.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import dayjs from 'dayjs'
 import { ChevronDown, ChevronLeft, ChevronRight, Info, X } from 'lucide-vue-next'
+import { exceedsBudget } from '@/utils/budgetValidation'
 
 // ==========================================
 // 1. 타입 정의 (DB 카테고리와 완벽 일치)
@@ -20,6 +21,7 @@ export type Category =
 interface Props {
   isOpen: boolean
   selectedDate: string
+  maxAmount?: number
 }
 
 const props = defineProps<Props>()
@@ -281,6 +283,12 @@ const handleSave = () => {
     amountError.value = '0원은 저장할 수 없습니다. 금액을 입력해주세요.'
     return
   }
+
+  if (exceedsBudget(numericAmount, props.maxAmount)) {
+    amountError.value = '지출 금액은 생활비를 초과할 수 없습니다.'
+    return
+  }
+
   amountError.value = ''
 
   // 원래 약속된 형식대로 5가지 데이터를 모두 담아서 부모(HomePage)에게 쏩니다!

--- a/src/pages/Setup/ExpenseGoalSetup.vue
+++ b/src/pages/Setup/ExpenseGoalSetup.vue
@@ -3,6 +3,11 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useBudgetStore } from '@/stores/useBudgetStore'
 import {
+  calculateStockTargetAmount,
+  exceedsBudget,
+  isBudgetExceededError,
+} from '@/utils/budgetValidation'
+import {
   X,
   Wallet,
   Search,
@@ -32,14 +37,34 @@ const targetQuantity = ref('')
 
 const isStockListOpen = ref(false)
 const showErrors = ref(false)
+const targetBudgetLimitMessage = '주식 목표 금액은 생활비를 초과할 수 없습니다.'
 
 const popularStocks = computed(() => budgetStore.stockOptions)
 const monthlyBudgetAmount = computed(() => Number(lastMonthExpense.value) || 0)
 const targetQuantityAmount = computed(() => Number(targetQuantity.value) || 0)
 const isMonthlyBudgetValid = computed(() => monthlyBudgetAmount.value > 0)
 const isTargetQuantityValid = computed(() => targetQuantityAmount.value > 0)
+const totalTargetAmount = computed(() => {
+  if (!selectedStock.value || !targetQuantity.value) return 0
+
+  return calculateStockTargetAmount({
+    stockPrice: selectedStock.value.price,
+    targetQuantity: targetQuantityAmount.value,
+  })
+})
+const isTargetAmountWithinBudget = computed(() => {
+  if (!selectedStock.value || !isTargetQuantityValid.value || !isMonthlyBudgetValid.value) {
+    return true
+  }
+
+  return !exceedsBudget(totalTargetAmount.value, monthlyBudgetAmount.value)
+})
 const isGoalSetupValid = computed(
-  () => isMonthlyBudgetValid.value && Boolean(selectedStock.value) && isTargetQuantityValid.value,
+  () =>
+    isMonthlyBudgetValid.value &&
+    Boolean(selectedStock.value) &&
+    isTargetQuantityValid.value &&
+    isTargetAmountWithinBudget.value,
 )
 
 const getUserId = () => {
@@ -95,14 +120,6 @@ onMounted(async () => {
   }
 })
 
-const totalTargetAmount = computed(() => {
-  if (!selectedStock.value || !targetQuantity.value) return 0
-  const quantityStr = targetQuantity.value.toString().replace(/[^0-9.]/g, '')
-  const quantity = parseFloat(quantityStr) || 0
-  const amount = selectedStock.value.price * quantity
-  return Math.min(amount, 99999999)
-})
-
 const onQuantityInput = (e) => {
   const inputVal = e.target.value
   const sanitized = inputVal.replace(/[^0-9.]/g, '')
@@ -155,6 +172,10 @@ const handleStartSaving = async () => {
     router.push('/home')
   } catch (error) {
     console.error('Failed to save settings to server:', error)
+    if (isBudgetExceededError(error)) {
+      alert(error.message)
+      return
+    }
     alert('서버와 통신하는 중 문제가 발생했습니다. json-server가 켜져 있는지 확인해주세요.')
   }
 }
@@ -340,6 +361,15 @@ const handleStartSaving = async () => {
               >주</span
             >
           </div>
+
+          <Motion
+            v-if="showErrors && !isTargetAmountWithinBudget"
+            :initial="{ opacity: 0, y: -10 }"
+            :animate="{ opacity: 1, y: 0 }"
+            class="text-red-500 text-sm font-bold px-1"
+          >
+            {{ targetBudgetLimitMessage }}
+          </Motion>
 
           <Motion
             v-if="showErrors && !isTargetQuantityValid"

--- a/src/pages/homePage/HomePage.vue
+++ b/src/pages/homePage/HomePage.vue
@@ -8,6 +8,7 @@ import ExpenseInput from '@/components/ExpenseInput.vue'
 
 import { storeToRefs } from 'pinia'
 import { useBudgetStore } from '@/stores/useBudgetStore'
+import { isBudgetExceededError } from '@/utils/budgetValidation'
 const weekdays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 
 const calendarDotTones = ['soft', 'warm', 'accent', 'dark']
@@ -215,6 +216,12 @@ async function handleExpenseSave(payload) {
     })
   } catch (error) {
     console.error('Failed to save expense:', error)
+    if (isBudgetExceededError(error)) {
+      toast.error(error.message, {
+        autoClose: 2200,
+      })
+      return
+    }
     toast.error('지출 저장에 실패했어요. json-server 상태를 확인해주세요.', {
       autoClose: 2200,
     })
@@ -350,6 +357,7 @@ async function handleExpenseSave(payload) {
         <ExpenseInput
           :is-open="isExpenseInputOpen"
           :selected-date="expenseInputDateKey"
+          :max-amount="budgetStore.budget"
           @close="closeExpenseInput"
           @save="handleExpenseSave"
         />

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -1,4 +1,8 @@
 import { defineStore } from 'pinia'
+import {
+  calculateStockTargetAmount,
+  validateAmountWithinBudget,
+} from '../utils/budgetValidation'
 
 const API_BASE = '/api'
 
@@ -325,11 +329,27 @@ export const useBudgetStore = defineStore('budget', {
         throw new Error('Cannot update goal setup without a selected member')
       }
 
+      if (this.prices.length === 0) {
+        await this.loadReferenceData()
+      }
+
       const payload = {
         monthlyBudget: toNumber(monthlyBudget),
         targetStockId,
         targetQuantity: toNumber(targetQuantity),
       }
+
+      const targetStockPrice = this.latestPriceByStockId.get(payload.targetStockId)?.price ?? 0
+      const targetAmount = calculateStockTargetAmount({
+        stockPrice: targetStockPrice,
+        targetQuantity: payload.targetQuantity,
+      })
+
+      validateAmountWithinBudget({
+        amount: targetAmount,
+        budget: payload.monthlyBudget,
+        message: '주식 목표 금액은 생활비를 초과할 수 없습니다.',
+      })
 
       const member = await requestJson(`/members/${this.memberId}`, {
         method: 'PATCH',
@@ -356,12 +376,20 @@ export const useBudgetStore = defineStore('budget', {
       const spentAt =
         payload.spentAt ?? `${payload.date}T${payload.time || new Date().toTimeString().slice(0, 5)}:00`
 
+      const amount = toNumber(payload.amount)
+
+      validateAmountWithinBudget({
+        amount,
+        budget: this.budget,
+        message: '지출 금액은 생활비를 초과할 수 없습니다.',
+      })
+
       const expense = await requestJson('/expenses', {
         method: 'POST',
         body: JSON.stringify({
           memberId: this.memberId,
           categoryId: category?.id ?? payload.categoryId ?? null,
-          amount: toNumber(payload.amount),
+          amount,
           memo: payload.memo || '직접 입력',
           spentAt,
         }),

--- a/src/utils/budgetValidation.js
+++ b/src/utils/budgetValidation.js
@@ -1,0 +1,37 @@
+export const BUDGET_EXCEEDED_ERROR_CODE = 'BUDGET_EXCEEDED'
+
+export class BudgetExceededError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'BudgetExceededError'
+    this.code = BUDGET_EXCEEDED_ERROR_CODE
+  }
+}
+
+export function toFiniteNumber(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function exceedsBudget(amount, budget) {
+  const numericAmount = toFiniteNumber(amount)
+  const numericBudget = toFiniteNumber(budget)
+
+  if (numericAmount === null || numericBudget === null) return false
+
+  return numericAmount > numericBudget
+}
+
+export function calculateStockTargetAmount({ stockPrice, targetQuantity }) {
+  return (toFiniteNumber(stockPrice) ?? 0) * (toFiniteNumber(targetQuantity) ?? 0)
+}
+
+export function validateAmountWithinBudget({ amount, budget, message }) {
+  if (exceedsBudget(amount, budget)) {
+    throw new BudgetExceededError(message)
+  }
+}
+
+export function isBudgetExceededError(error) {
+  return error?.code === BUDGET_EXCEEDED_ERROR_CODE
+}

--- a/src/utils/budgetValidation.test.js
+++ b/src/utils/budgetValidation.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  BudgetExceededError,
+  calculateStockTargetAmount,
+  exceedsBudget,
+  validateAmountWithinBudget,
+} from './budgetValidation.js'
+
+test('exceedsBudget returns true only when amount is greater than budget', () => {
+  assert.equal(exceedsBudget(1_000_001, 1_000_000), true)
+  assert.equal(exceedsBudget(1_000_000, 1_000_000), false)
+  assert.equal(exceedsBudget(999_999, 1_000_000), false)
+})
+
+test('validateAmountWithinBudget rejects values above budget', () => {
+  assert.throws(
+    () =>
+      validateAmountWithinBudget({
+        amount: 1_000_001,
+        budget: 1_000_000,
+        message: '생활비를 초과할 수 없습니다.',
+      }),
+    BudgetExceededError,
+  )
+})
+
+test('validateAmountWithinBudget allows values equal to budget', () => {
+  assert.doesNotThrow(() =>
+    validateAmountWithinBudget({
+      amount: 1_000_000,
+      budget: 1_000_000,
+      message: '생활비를 초과할 수 없습니다.',
+    }),
+  )
+})
+
+test('calculateStockTargetAmount multiplies stock price by target quantity', () => {
+  assert.equal(calculateStockTargetAmount({ stockPrice: 210_500, targetQuantity: 2 }), 421_000)
+})


### PR DESCRIPTION
## 🚀 PR 개요
- 작업 내용 요약: 생활비를 초과하는 지출 입력과 주식 목표 설정을 저장 전 거절하도록 검증 로직을 추가했습니다.
- 관련 이슈: #87

---

## ✨ 변경 사항
- 지출 입력 금액이 생활비보다 큰 경우 저장되지 않도록 검증 추가
- 주식 목표 금액(주가 * 목표 수량)이 생활비보다 큰 경우 목표 설정 저장 차단
- 생활비 초과 검증 공통 유틸 및 단위 테스트 추가

---

## 🧩 작업 유형
- [x] 🐛 Bug Fix
- [ ] ✨ Feature
- [x] 🔧 Refactor
- [ ] 🎨 UI/UX
- [ ] 🔌 API
- [ ] ⚡ Performance
- [x] ⚙️ Config / Build

---

## 📍 주요 변경 파일
- `src/utils/budgetValidation.js`
- `src/utils/budgetValidation.test.js`
- `src/stores/useBudgetStore.js`
- `src/components/ExpenseInput.vue`
- `src/pages/Setup/ExpenseGoalSetup.vue`
- `src/pages/homePage/HomePage.vue`
- `package.json`

---

## 🖼️ 스크린샷 (선택)
> UI 변경 시 필수

- 지출 입력/목표 설정 화면에 생활비 초과 안내 메시지가 표시됩니다.
- 별도 스크린샷은 첨부하지 않았습니다.

---

## 🧪 테스트 방법
1. `npm run test:unit`
2. `npm run build`
3. 생활비보다 큰 지출 금액 또는 주식 목표 금액을 입력했을 때 저장이 거절되는지 확인

---

## ⚠️ 체크리스트
- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] 불필요한 코드 제거
- [x] 기존 기능 영향 없음
- [ ] 반응형/UI 확인 (필요 시)

---

## 💬 기타 사항
- 생활비와 같은 금액은 허용하고, 생활비보다 큰 경우만 거절하도록 처리했습니다.
- ESLint 전체 검사는 기존 `ExpenseInput.vue` TypeScript 파서 설정 및 기존 미사용 함수 이슈로 실패하여, 이번 변경 검증은 단위 테스트와 빌드로 확인했습니다.
